### PR TITLE
converted BaseDatetimeTransformer to narwhals

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,7 +37,7 @@ Changed
 - narwhalified BaseNumericTransformer `#358 https://github.com/lvgig/tubular/issues/358`
 - narwhalified DropOriginalMixin `#352 <https://github.com/lvgig/tubular/issues/352>_`
 - narwhalified BaseMappingTransformer `#367 <https://github.com/lvgig/tubular/issues/367>_`
-- placeholder
+- narwhalified BaseDatetimeTransformer `#375 <https://github.com/azukds/tubular/issues/375>`
 - placeholder
 - placeholder
 - placeholder

--- a/tests/dates/test_BaseDatetimeTransformer.py
+++ b/tests/dates/test_BaseDatetimeTransformer.py
@@ -1,7 +1,9 @@
 from copy import deepcopy
 
+import narwhals as nw
 import numpy as np
 import pandas as pd
+import polars as pl
 import pytest
 
 from tests.base_tests import (
@@ -17,6 +19,11 @@ from tests.base_tests import (
 class DatetimeMixinTransformTests:
     """Generic tests for Datetime Transformers"""
 
+    @pytest.mark.parametrize(
+        "minimal_dataframe_lookup",
+        ["pandas", "polars"],
+        indirect=["minimal_dataframe_lookup"],
+    )
     @pytest.mark.parametrize(
         ("bad_value", "bad_type"),
         [
@@ -34,24 +41,35 @@ class DatetimeMixinTransformTests:
         bad_value,
         bad_type,
     ):
-        "Test that transform raises an error if columns contains non date types"
+        "Test that transform raises an error if columns contains non datetime types"
 
         args = minimal_attribute_dict[self.transformer_name].copy()
-
-        # pull out columns arg to use below, and remove from dict
         columns = args["columns"]
 
-        for i in range(len(columns)):
-            df = deepcopy(minimal_dataframe_lookup[self.transformer_name])
-            col = columns[i]
-            df[col] = bad_value
-            # force date test to wanted type
-            if bad_type == "Date":
-                df[col] = df[col].astype("date32[pyarrow]")
+        transformer = uninitialized_transformers[self.transformer_name](
+            **args,
+        )
 
-            x = uninitialized_transformers[self.transformer_name](
-                **args,
-            )
+        df = deepcopy(minimal_dataframe_lookup[self.transformer_name])
+
+        # if transformer is not yet polars compatible, skip this test
+        if not transformer.polars_compatible and isinstance(df, pl.DataFrame):
+            return
+
+        for i in range(len(columns)):
+            col = columns[i]
+            # force date test to wanted type if pandas df, to avoid
+            # narwhals NotImplementedError where Date dtype is only
+            # supported for pyarrow-backed dtypes in pandas
+            if bad_type == "Date" and isinstance(df, pd.DataFrame):
+                bad_df = deepcopy(df)
+                bad_df[col] = bad_df[col].astype("date32[pyarrow]")
+                bad_df = nw.from_native(bad_df)
+            else:
+                bad_df = nw.from_native(df).clone()
+                bad_df = bad_df.with_columns(
+                    nw.lit(bad_value).cast(getattr(nw, bad_type)).alias(col),
+                )
 
             msg = rf"{col} type should be in \['datetime64'\] but got {bad_type}"
 
@@ -59,7 +77,7 @@ class DatetimeMixinTransformTests:
                 TypeError,
                 match=msg,
             ):
-                x.transform(df)
+                transformer.transform(nw.to_native(bad_df))
 
 
 class TestInit(

--- a/tubular/dates.py
+++ b/tubular/dates.py
@@ -186,7 +186,7 @@ class BaseDatetimeTransformer(BaseGenericDateTransformer):
         class attribute, indicates whether transformer has been converted to polars/pandas agnostic narwhals framework
     """
 
-    polars_compatible = False
+    polars_compatible = True
 
     def __init__(
         self,
@@ -202,20 +202,21 @@ class BaseDatetimeTransformer(BaseGenericDateTransformer):
             **kwargs,
         )
 
+    @nw.narwhalify
     def transform(
         self,
-        X: pd.DataFrame,
-    ) -> pd.DataFrame:
+        X: FrameT,
+    ) -> FrameT:
         """base transform method for transformers that operate exclusively on datetime columns
 
         Parameters
         ----------
-        X : pd.DataFrame
+        X : pd/pl.DataFrame
             Data containing self.columns
 
         Returns
         -------
-        X : pd.DataFrame
+        X : pd/pl.DataFrame
             Validated data
 
         """


### PR DESCRIPTION
Made BaseDatetimeTransformer polars compatible and updated tests. Kept the structure of test_BaseDatetimeTransformer similar to avoid error with converting pandas data frame to date type. Explanation in code comments.

#375