### PR TITLE
Optional wanted_values feature added to OHE

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,9 +38,12 @@ Changed
 - narwhalified DropOriginalMixin `#352 <https://github.com/lvgig/tubular/issues/352>_`
 - narwhalified BaseMappingTransformer `#367 <https://github.com/lvgig/tubular/issues/367>_`
 - narwhalified BaseDatetimeTransformer `#375 <https://github.com/azukds/tubular/issues/375>`
+- Optional wanted_levels feature has been integrated into the OneHotEncodingTransformer which allows users to specify which levels in a column they wish to encode. `#384 <https://github.com/azukds/tubular/issues/384>_`
+- Created unit tests to check if the values provided for wanted_values are as expected and if the output is as expected.
 - placeholder
 - placeholder
-- placeholder
+
+
 
 1.4.1 (02/12/2024)
 ------------------

--- a/tests/nominal/test_OneHotEncodingTransformer.py
+++ b/tests/nominal/test_OneHotEncodingTransformer.py
@@ -26,6 +26,19 @@ class TestInit(
     def setup_class(cls):
         cls.transformer_name = "OneHotEncodingTransformer"
 
+    @pytest.mark.parametrize(
+            "values", 
+            [{'b': ['a', 'b']}, 'a', ['a', 'b'], 123, True],
+    )
+    def test_wanted_values_is_dict(self, values):
+        df= d.create_df_1()
+ 
+        with pytest.raises(
+            TypeError,
+            match= 'OneHotEncodingTransformer: Wanted_values should be a dictionary',
+        ):
+            self.OneHotEncodingTransformer(wanted_values = values)
+
 
 class TestFit(GenericFitTests):
     """Generic tests for transformer.fit()"""

--- a/tests/nominal/test_OneHotEncodingTransformer.py
+++ b/tests/nominal/test_OneHotEncodingTransformer.py
@@ -26,18 +26,82 @@ class TestInit(
     def setup_class(cls):
         cls.transformer_name = "OneHotEncodingTransformer"
 
+   
+    # Tests for wanted_values parameter
+
     @pytest.mark.parametrize(
             "values", 
-            [{'b': ['a', 'b']}, 'a', ['a', 'b'], 123, True],
+            [ "a", ["a", "b"], 123, True],
     )
-    def test_wanted_values_is_dict(self, values):
-        df= d.create_df_1()
+    def test_wanted_values_is_dict(self, values, minimal_attribute_dict):
+        args = minimal_attribute_dict[self.transformer_name]
+        args["wanted_values"]=values
  
         with pytest.raises(
             TypeError,
-            match= 'OneHotEncodingTransformer: Wanted_values should be a dictionary',
+            match= "OneHotEncodingTransformer: Wanted_values should be a dictionary",
         ):
-            self.OneHotEncodingTransformer(wanted_values = values)
+            OneHotEncodingTransformer(**args)
+
+
+    @pytest.mark.parametrize(
+            "values",
+            [
+                {1:["a", "b"]},
+                {True:["a"]},
+                {("a",):["b", "c"]},
+            ]
+    )
+    def test_wanted_values_key_is_str(self, values, minimal_attribute_dict):
+        args = minimal_attribute_dict[self.transformer_name]
+        args["wanted_values"]= values
+ 
+        with pytest.raises(
+            TypeError,
+            match= "OneHotEncodingTransformer:  Key in 'wanted_values' should be a string",
+        ):
+            OneHotEncodingTransformer(**args)
+
+
+    @pytest.mark.parametrize(
+        "values",
+        [
+            {"a": "b"},
+            {"a":("a","b")},
+            {"a": True},
+            {"a": 123},
+        ]
+    )
+    def test_wanted_values_value_is_list(self, values, minimal_attribute_dict):
+        args = minimal_attribute_dict[self.transformer_name]
+        args["wanted_values"] = values
+
+        with pytest.raises(
+            TypeError,
+            match="OneHotEncodingTransformer: Values in the 'wanted_values' dictionary should be a list",
+        ):
+            OneHotEncodingTransformer(**args)
+
+
+    @pytest.mark.parametrize(
+        "values",
+        [
+            {"a": ["b", 123]},
+            {"a": ["b", True]},
+            {"a": ["b", None]},
+            {"a": ["b", ["a", "b"]]},
+        ]
+    )
+    def test_wanted_values_entries_are_str(self, values, minimal_attribute_dict):
+        args= minimal_attribute_dict[self.transformer_name]
+        args["wanted_values"]= values
+
+        with pytest.raises(
+            TypeError,
+            match= "OneHotEncodingTransformer: Entries in 'wanted_values' list should be a string"
+        ):
+            OneHotEncodingTransformer(**args)
+            
 
 
 class TestFit(GenericFitTests):

--- a/tests/nominal/test_OneHotEncodingTransformer.py
+++ b/tests/nominal/test_OneHotEncodingTransformer.py
@@ -514,5 +514,6 @@ class TestTransform(
 
         with pytest.warns(None) as warnings:
             transformer.transform(df_test)
-        assert len(warnings) == 0
-        
+        assert (
+            len(warnings) == 0
+        ), "OneHotEncodingTransformer.transform is raising unexpected warnings"

--- a/tests/nominal/test_OneHotEncodingTransformer.py
+++ b/tests/nominal/test_OneHotEncodingTransformer.py
@@ -165,7 +165,7 @@ class TestFit(GenericFitTests):
         "library",
         ["pandas", "polars"],
     )
-    def test_fit_no_warning_if_all_wanted_values_present(self, library):
+    def test_fit_no_warning_if_all_wanted_values_present(self, library, recwarn):
         """Test that OneHotEncodingTransformer.fit does NOT raise a warning when all levels in wanted_levels are present in the data."""
         df = d.create_df_1(library=library)
 
@@ -174,9 +174,10 @@ class TestFit(GenericFitTests):
             wanted_values={"b": ["a", "b", "c", "d", "e", "f"]},
         )
 
-        with pytest.warns(None) as warnings:
-            transformer.fit(df)
-        assert len(warnings) == 0
+        transformer.fit(df)
+        assert (
+            len(recwarn) == 0
+        ), "OneHotEncodingTransformer.fit is raising unexpected warnings"
 
 
 class TestTransform(
@@ -501,7 +502,7 @@ class TestTransform(
         "library",
         ["pandas", "polars"],
     )
-    def test_transform_no_warning_if_all_wanted_values_present(self, library):
+    def test_transform_no_warning_if_all_wanted_values_present(self, library, recwarn):
         """Test that OneHotEncodingTransformer.transform does NOT raise a warning when all levels in wanted_levels are present in the data."""
         df_train = d.create_df_8(library=library)
         df_test = d.create_df_7(library=library)
@@ -511,9 +512,8 @@ class TestTransform(
             wanted_values={"b": ["z", "y", "x"]},
         )
         transformer.fit(df_train)
+        transformer.transform(df_test)
 
-        with pytest.warns(None) as warnings:
-            transformer.transform(df_test)
         assert (
-            len(warnings) == 0
+            len(recwarn) == 0
         ), "OneHotEncodingTransformer.transform is raising unexpected warnings"

--- a/tests/nominal/test_OneHotEncodingTransformer.py
+++ b/tests/nominal/test_OneHotEncodingTransformer.py
@@ -170,11 +170,13 @@ class TestFit(GenericFitTests):
         df = d.create_df_1(library=library)
 
         transformer = OneHotEncodingTransformer(
-            columns=["b"], wanted_values={"b": ["a", "b", "c", "d", "e", "f"]}
+            columns=["b"],
+            wanted_values={"b": ["a", "b", "c", "d", "e", "f"]},
         )
 
-        with pytest.warns(None):
+        with pytest.warns(None) as warnings:
             transformer.fit(df)
+        assert len(warnings) == 0
 
 
 class TestTransform(
@@ -501,13 +503,16 @@ class TestTransform(
     )
     def test_transform_no_warning_if_all_wanted_values_present(self, library):
         """Test that OneHotEncodingTransformer.transform does NOT raise a warning when all levels in wanted_levels are present in the data."""
-        df_train = d.create_df_7(library=library)
-        df_test = d.create_df_8(library=library)
+        df_train = d.create_df_8(library=library)
+        df_test = d.create_df_7(library=library)
 
         transformer = OneHotEncodingTransformer(
-            columns=["b"], wanted_values={"b": ["x", "z", "y"]}
+            columns=["b"],
+            wanted_values={"b": ["z", "y", "x"]},
         )
         transformer.fit(df_train)
 
-        with pytest.warns(None):
+        with pytest.warns(None) as warnings:
             transformer.transform(df_test)
+        assert len(warnings) == 0
+        

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -1123,6 +1123,7 @@ class OneHotEncodingTransformer(
     def __init__(
         self,
         columns: str | list[str] | None = None,
+        values: list[str] | None = None,
         separator: str = "_",
         drop_original: bool = False,
         copy: bool | None = None,

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -1087,6 +1087,9 @@ class OneHotEncodingTransformer(
         Names of columns to transform. If the default of None is supplied all object and category
         columns in X are used.
 
+    values: list of strings or None, default = None
+        Optional parameter to select specific columns to be transformed. If it is None, all categorical columns will be encoded.
+
     separator : str
         Used to create dummy column names, the name will take
         the format [categorical feature][separator][category level]
@@ -1138,6 +1141,7 @@ class OneHotEncodingTransformer(
             **kwargs,
         )
 
+        self.values = values
         self.set_drop_original_column(drop_original)
         self.check_and_set_separator_column(separator)
 
@@ -1188,6 +1192,22 @@ class OneHotEncodingTransformer(
             self.categories_[c] = levels_list
 
             self.new_feature_names_[c] = self._get_feature_names(column=c)
+
+        # filter categories if values is provided
+        if self.values is not None:
+            self.categories_ = {
+                c: self.categories_[c] for c in self.values if c in self.categories_
+            }
+            self.new_feature_names_ = {
+                c: self.new_feature_names_[c]
+                for c in self.values
+                if c in self.new_feature_names_
+            }
+
+        # checks if column in 'values' exist in categories
+        if not self.categories_:
+            error_message = "No valid columns in 'values' for encoding"
+            raise ValueError(error_message)
 
         return self
 

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -1297,6 +1297,10 @@ class OneHotEncodingTransformer(
             The column name being checked for missing user-specified levels.
         missing_levels: dict[str, list[str]]
             Dictionary containing missing user-specified levels for each column.
+        Returns
+        -------
+        missing_levels : dict[str, list[str]]
+            Dictionary updated to reflect new missing levels for column c
 
         """
         # print warning for missing levels

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -1143,24 +1143,24 @@ class OneHotEncodingTransformer(
 
         if wanted_values is not None:
             if not isinstance(wanted_values, dict):
-                msg = "Wanted_values should be a dictionary"
+                msg = f"{self.classname()}: Wanted_values should be a dictionary"
                 raise TypeError(msg)
 
             for key, val_list in wanted_values.items():
                 # check key is a string
                 if not isinstance(key, str):
-                    msg = "Key in 'wanted_values' should be a string"
+                    msg = f"{self.classname()}:  Key in 'wanted_values' should be a string"
                     raise TypeError(msg)
 
                 # check value is a list
                 if not isinstance(val_list, list):
-                    msg = "Values in the 'wanted_values' dictionary should be a list"
+                    msg = f"{self.classname()}: Values in the 'wanted_values' dictionary should be a list"
                     raise TypeError(msg)
 
                 # check if each value within the list is a string
                 for val in val_list:
                     if not isinstance(val, str):
-                        msg = "Entries in 'wanted_values' list should be a string "
+                        msg = f"{self.classname()}: Entries in 'wanted_values' list should be a string"
                         raise TypeError(msg)
 
         self.wanted_values = wanted_values

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -1143,7 +1143,7 @@ class OneHotEncodingTransformer(
 
         if wanted_values is not None:
             if not isinstance(wanted_values, dict):
-                msg = f"{self.classname()}: Wanted_values should be a dictionary"
+                msg = f"{self.classname()}: wanted_values should be a dictionary"
                 raise TypeError(msg)
 
             for key, val_list in wanted_values.items():
@@ -1225,7 +1225,7 @@ class OneHotEncodingTransformer(
             self.categories_[c] = final_categories
             self.new_feature_names_[c] = self._get_feature_names(column=c)
 
-            present_levels = set(X.select(nw.col(c).unique()).get_column(c).to_list())
+            present_levels = set(X.get_column(c).unique().to_list())
             missing_levels = self._warn_missing_levels(
                 present_levels,
                 c,
@@ -1239,12 +1239,24 @@ class OneHotEncodingTransformer(
         present_levels: list,
         c: str,
         missing_levels: dict[str, list[str]],
-    ) -> list:
+    ) -> dict[str, list[str]]:
+        """Logs a warning for user-specifed levels that are not found in the dataset and updates "missing_levels[c]" with those missing levels.
+
+        Parameters
+        ----------
+        present_levels: list
+            List of levels observed in the data.
+        c: str
+            The column name being checked for missing user-specified levels.
+        missing_levels: dict[str, list[str]]
+            Dictionary containing missing user-specified levels for each column.
+
+        """
         # print warning for missing levels
         missing_levels[c] = list(
             set(self.categories_[c]).difference(present_levels),
         )
-        if len(missing_levels) > 0:
+        if len(missing_levels[c]) > 0:
             warning_msg = f"{self.classname()}: column {c} includes user-specified values {missing_levels[c]} not found in the dataset"
             warnings.warn(warning_msg, UserWarning, stacklevel=2)
 
@@ -1300,7 +1312,7 @@ class OneHotEncodingTransformer(
                 )
 
             # print warning for unseen levels
-            present_levels = set(X.select(nw.col(c).unique()).get_column(c).to_list())
+            present_levels = set(X.get_column(c).unique().to_list())
             unseen_levels = present_levels.difference(set(self.categories_[c]))
             if len(unseen_levels) > 0:
                 warning_msg = f"{self.classname()}: column {c} has unseen categories: {unseen_levels}"

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -1227,7 +1227,9 @@ class OneHotEncodingTransformer(
 
             present_levels = set(X.select(nw.col(c).unique()).get_column(c).to_list())
             missing_levels = self._warn_missing_levels(
-                present_levels, c, missing_levels
+                present_levels,
+                c,
+                missing_levels,
             )
 
         return self
@@ -1242,7 +1244,7 @@ class OneHotEncodingTransformer(
         missing_levels[c] = list(
             set(self.categories_[c]).difference(present_levels),
         )
-        if missing_levels:
+        if len(missing_levels) > 0:
             warning_msg = f"{self.classname()}: column {c} includes user-specified values {missing_levels[c]} not found in the dataset"
             warnings.warn(warning_msg, UserWarning, stacklevel=2)
 


### PR DESCRIPTION
An optional feature, "wanted_levels," has been integrated into the OneHotEncodingTransformer. This feature allows users to specify which levels in a column they wish to encode. 
If "wanted_levels" is set to None, the transformer will encode all levels present in the columns. 
Additionally, new tests have been added to the test suite to validate the performance of this feature.