### PR TITLE
♻️ changed native_namespace -> backend

### DIFF
--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -504,7 +504,7 @@ class WeightColumnFitMixinTests:
             return
 
         df = nw.from_native(df)
-        native_namespace = nw.get_native_namespace(df)
+        native_backend = nw.get_native_namespace(df)
 
         args = minimal_attribute_dict[self.transformer_name].copy()
         # insert weight column
@@ -514,7 +514,7 @@ class WeightColumnFitMixinTests:
             nw.new_series(
                 weight_column,
                 np.arange(1, len(df) + 1),
-                native_namespace=native_namespace,
+                backend=native_backend,
             ),
         )
 
@@ -551,14 +551,14 @@ class WeightColumnFitMixinTests:
             return
 
         df = nw.from_native(df)
-        native_namespace = nw.get_native_namespace(df)
+        native_backend = nw.get_native_namespace(df)
         # insert weight column
         weight_column = "weight_column"
         df = df.with_columns(
             nw.new_series(
                 weight_column,
                 np.arange(1, len(df) + 1),
-                native_namespace=native_namespace,
+                backend=native_backend,
             ),
         )
 
@@ -612,7 +612,7 @@ class WeightColumnFitMixinTests:
             return
 
         df = nw.from_native(df)
-        native_namespace = nw.get_native_namespace(df)
+        native_backend = nw.get_native_namespace(df)
 
         args = minimal_attribute_dict[self.transformer_name].copy()
         weight_column = "weight_column"
@@ -622,7 +622,7 @@ class WeightColumnFitMixinTests:
             nw.new_series(
                 weight_column,
                 [*[bad_weight_value], *np.arange(2, len(df) + 1)],
-                native_namespace=native_namespace,
+                backend=native_backend,
             ),
         )
 

--- a/tests/capping/test_BaseCappingTransformer.py
+++ b/tests/capping/test_BaseCappingTransformer.py
@@ -530,12 +530,12 @@ class GenericCappingTransformTests(GenericTransformTests):
 
         # convert column to non-numeric
         df = nw.from_native(df)
-        native_namespace = nw.get_native_namespace(df)
+        native_backend = nw.get_native_namespace(df)
         df = df.with_columns(
             nw.new_series(
                 name="a",
                 values=["a"] * len(df),
-                native_namespace=native_namespace,
+                backend=native_backend,
             ),
         )
 

--- a/tests/dates/test_BetweenDatesTransformer.py
+++ b/tests/dates/test_BetweenDatesTransformer.py
@@ -80,12 +80,12 @@ def expected_df_1(library="pandas"):
     df = d.create_is_between_dates_df_1(library=library)
 
     df = nw.from_native(df)
-    native_namespace = nw.get_native_namespace(df)
+    native_backend = nw.get_native_namespace(df)
     df = df.with_columns(
         nw.new_series(
             name="d",
             values=[True, False],
-            backend=native_namespace.__name__,
+            backend=native_backend.__name__,
         ),
     )
 
@@ -97,12 +97,12 @@ def expected_df_2(library="pandas"):
     df = d.create_is_between_dates_df_2(library=library)
 
     df = nw.from_native(df)
-    native_namespace = nw.get_native_namespace(df)
+    native_backend = nw.get_native_namespace(df)
     df = df.with_columns(
         nw.new_series(
             name="e",
             values=[False, False, True, True, False, False],
-            backend=native_namespace.__name__,
+            backend=native_backend.__name__,
         ),
     )
 
@@ -114,12 +114,12 @@ def expected_df_3(library="pandas"):
     df = d.create_is_between_dates_df_2(library=library)
 
     df = nw.from_native(df)
-    native_namespace = nw.get_native_namespace(df)
+    native_backend = nw.get_native_namespace(df)
     df = df.with_columns(
         nw.new_series(
             name="e",
             values=[False, False, True, True, True, False],
-            backend=native_namespace.__name__,
+            backend=native_backend.__name__,
         ),
     )
 
@@ -131,12 +131,12 @@ def expected_df_4(library="pandas"):
     df = d.create_is_between_dates_df_2(library=library)
 
     df = nw.from_native(df)
-    native_namespace = nw.get_native_namespace(df)
+    native_backend = nw.get_native_namespace(df)
     df = df.with_columns(
         nw.new_series(
             name="e",
             values=[False, True, True, True, False, False],
-            backend=native_namespace.__name__,
+            backend=native_backend.__name__,
         ),
     )
 
@@ -148,12 +148,12 @@ def expected_df_5(library="pandas"):
     df = d.create_is_between_dates_df_2(library=library)
 
     df = nw.from_native(df)
-    native_namespace = nw.get_native_namespace(df)
+    native_backend = nw.get_native_namespace(df)
     df = df.with_columns(
         nw.new_series(
             name="e",
             values=[False, True, True, True, True, False],
-            backend=native_namespace.__name__,
+            backend=native_backend.__name__,
         ),
     )
 

--- a/tests/imputers/test_MedianImputer.py
+++ b/tests/imputers/test_MedianImputer.py
@@ -40,14 +40,14 @@ class TestFit(WeightColumnFitMixinTests, GenericFitTests):
         df = d.create_df_3(library=library)
 
         df = nw.from_native(df)
-        native_namespace = nw.get_native_namespace(df)
+        native_backend = nw.get_native_namespace(df)
 
         # replace 'a' with all null values to trigger warning
         df = df.with_columns(
             nw.new_series(
                 name="d",
                 values=[None] * len(df),
-                native_namespace=native_namespace,
+                backend=native_backend,
             ),
         )
 
@@ -70,14 +70,14 @@ class TestFit(WeightColumnFitMixinTests, GenericFitTests):
         df = d.create_df_9(library=library)
 
         df = nw.from_native(df)
-        native_namespace = nw.get_native_namespace(df)
+        native_backend = nw.get_native_namespace(df)
 
         # replace 'a' with all null values to trigger warning
         df = df.with_columns(
             nw.new_series(
                 name="d",
                 values=[None] * len(df),
-                native_namespace=native_namespace,
+                backend=native_backend,
             ),
         )
 

--- a/tests/imputers/test_ModeImputer.py
+++ b/tests/imputers/test_ModeImputer.py
@@ -232,14 +232,14 @@ class TestFit(WeightColumnFitMixinTests, GenericFitTests):
         df = d.create_weighted_imputers_test_df(library=library)
 
         df = nw.from_native(df)
-        native_namespace = nw.get_native_namespace(df)
+        native_backend = nw.get_native_namespace(df)
 
         # replace 'a' with all null values to trigger warning
         df = df.with_columns(
             nw.new_series(
                 name="a",
                 values=[None] * len(df),
-                native_namespace=native_namespace,
+                backend=native_backend,
             ),
         )
 

--- a/tests/mixins/test_WeightColumnMixin.py
+++ b/tests/mixins/test_WeightColumnMixin.py
@@ -53,7 +53,7 @@ class TestCheckWeightsColumn:
         obj = WeightColumnMixin()
 
         df = nw.from_native(df)
-        native_namespace = nw.get_native_namespace(df)
+        native_backend = nw.get_native_namespace(df)
 
         weight_column = "weight_column"
 
@@ -61,7 +61,7 @@ class TestCheckWeightsColumn:
             nw.new_series(
                 weight_column,
                 [*[bad_weight_value], *np.arange(2, len(df) + 1)],
-                native_namespace=native_namespace,
+                backend=native_backend,
             ),
         )
 

--- a/tests/nominal/test_GroupRareLevelsTransformer.py
+++ b/tests/nominal/test_GroupRareLevelsTransformer.py
@@ -333,13 +333,13 @@ class TestTransform(GenericNominalTransformTests):
         x.fit(df)
 
         df = nw.from_native(df)
-        native_namespace = nw.get_native_namespace(df)
+        native_backend = nw.get_native_namespace(df)
 
         df = df.with_columns(
             nw.new_series(
                 name="b",
                 values=["w", "w", "z", "y", "unseen_level"],
-                native_namespace=native_namespace,
+                backend=native_backend,
             ),
         ).to_native()
 

--- a/tests/nominal/test_MeanResponseTransformer.py
+++ b/tests/nominal/test_MeanResponseTransformer.py
@@ -725,12 +725,12 @@ class TestFitBinaryResponse(GenericFitTests, WeightColumnFitMixinTests):
 
         df = nw.from_native(df)
         weights_column = "weights_column"
-        native_namespace = nw.get_native_namespace(df)
+        native_backend = nw.get_native_namespace(df)
         df = df.with_columns(
             nw.new_series(
                 name=weights_column,
                 values=[1, 1, 1, 2, 2, 2],
-                backend=native_namespace.__name__,
+                backend=native_backend.__name__,
             ),
         )
 
@@ -796,7 +796,7 @@ class TestFitBinaryResponse(GenericFitTests, WeightColumnFitMixinTests):
 
         df = nw.from_native(df)
         weights_column = "weights_column"
-        native_namespace = nw.get_native_namespace(df)
+        native_backend = nw.get_native_namespace(df)
 
         # column f looks like [False, False, False, True, True, True]
         df = df.with_columns(
@@ -810,7 +810,7 @@ class TestFitBinaryResponse(GenericFitTests, WeightColumnFitMixinTests):
                     high_weight,
                     high_weight,
                 ],
-                backend=native_namespace.__name__,
+                backend=native_backend.__name__,
             ),
         )
 

--- a/tests/numeric/test_BaseNumericTransformer.py
+++ b/tests/numeric/test_BaseNumericTransformer.py
@@ -51,12 +51,12 @@ class BaseNumericTransformerFitTests(GenericFitTests):
 
         # add in 'target column' for fit
         df = nw.from_native(df)
-        native_namespace = nw.get_native_namespace(df).__name__
+        native_backend = nw.get_native_namespace(df).__name__
         df = df.with_columns(
             nw.new_series(
                 name="c",
                 values=[1] * len(df),
-                backend=native_namespace,
+                backend=native_backend,
             ),
         ).to_native()
 
@@ -96,11 +96,11 @@ class BaseNumericTransformerFitTests(GenericFitTests):
 
         # add in 'target column' for fit
         df = nw.from_native(df)
-        native_namespace = nw.get_native_namespace(df).__name__
+        native_backend = nw.get_native_namespace(df).__name__
 
         # Add this as OneDKmeansTransformer does not accept missing values:
         if self.transformer_name == "OneDKmeansTransformer":
-            if native_namespace == "polars":
+            if native_backend == "polars":
                 df = df.with_columns(
                     nw.when(
                         nw.col(cols[0]).is_nan(),
@@ -121,7 +121,7 @@ class BaseNumericTransformerFitTests(GenericFitTests):
             nw.new_series(
                 name="c",
                 values=[1] * len(df),
-                backend=native_namespace,
+                backend=native_backend,
             ),
         ).to_native()
 
@@ -165,7 +165,7 @@ class BaseNumericTransformerTransformTests(
 
         # add in 'target column' for and additional numeric column fit
         df = nw.from_native(df)
-        native_namespace = nw.get_native_namespace(df).__name__
+        native_backend = nw.get_native_namespace(df).__name__
 
         # Add this as samples dont have enough volumn for 8 default clusters
         if self.transformer_name == "OneDKmeansTransformer":
@@ -176,7 +176,7 @@ class BaseNumericTransformerTransformTests(
             nw.new_series(
                 name="c",
                 values=[1] * len(df),
-                backend=native_namespace,
+                backend=native_backend,
             ),
         ).to_native()
 
@@ -220,11 +220,11 @@ class BaseNumericTransformerTransformTests(
 
         # add in 'target column' for and additional numeric column fit
         df = nw.from_native(df)
-        native_namespace = nw.get_native_namespace(df).__name__
+        native_backend = nw.get_native_namespace(df).__name__
 
         # Add this as OneDKmeansTransformer does not accept missing values:
         if self.transformer_name == "OneDKmeansTransformer":
-            if native_namespace == "polars":
+            if native_backend == "polars":
                 df = df.with_columns(
                     nw.when(
                         nw.col("a").is_nan(),
@@ -245,12 +245,12 @@ class BaseNumericTransformerTransformTests(
             nw.new_series(
                 name="c",
                 values=[1] * len(df),
-                backend=native_namespace,
+                backend=native_backend,
             ),
             nw.new_series(
                 name="b",
                 values=[1] * len(df),
-                backend=native_namespace,
+                backend=native_backend,
             ),
         ).to_native()
 

--- a/tubular/capping.py
+++ b/tubular/capping.py
@@ -190,7 +190,7 @@ class BaseCappingTransformer(BaseNumericTransformer, WeightColumnMixin):
 
         self.quantile_capping_values = {}
 
-        native_namespace = nw.get_native_namespace(X)
+        native_backend = nw.get_native_namespace(X)
 
         if self.quantiles is not None:
             for col in self.columns:
@@ -200,7 +200,7 @@ class BaseCappingTransformer(BaseNumericTransformer, WeightColumnMixin):
                         nw.new_series(
                             name="dummy_weights_column",
                             values=[1] * len(X),
-                            native_namespace=native_namespace,
+                            backend=native_backend,
                         ),
                     )
 

--- a/tubular/imputers.py
+++ b/tubular/imputers.py
@@ -519,12 +519,12 @@ class ModeImputer(BaseImputer, WeightColumnMixin):
 
         else:
             weights_column = "dummy_unit_weights"
-            native_namespace = nw.get_native_namespace(X)
+            native_backend = nw.get_native_namespace(X)
             X = X.with_columns(
                 nw.new_series(
                     name=weights_column,
                     values=[1] * len(X),
-                    backend=native_namespace.__name__,
+                    backend=native_backend.__name__,
                 ),
             )
 

--- a/tubular/mapping.py
+++ b/tubular/mapping.py
@@ -151,7 +151,7 @@ class BaseMappingTransformMixin(BaseTransformer):
         self.check_is_fitted(["mappings", "return_dtypes"])
 
         X = nw.from_native(super().transform(X))
-        native_namespace = nw.get_native_namespace(X)
+        native_backend = nw.get_native_namespace(X)
 
         # will do a join further down, which does not preserve index
         # polars does not care about this, but pandas does,
@@ -181,7 +181,7 @@ class BaseMappingTransformMixin(BaseTransformer):
                     col: X.get_column(col).dtype,
                     new_col_values: getattr(nw, self.return_dtypes[col]),
                 },
-                native_namespace=native_namespace,
+                backend=native_backend,
             )
 
             X = (

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -419,7 +419,7 @@ class GroupRareLevelsTransformer(BaseTransformer, WeightColumnMixin):
         if self.record_rare_levels:
             self.rare_levels_record_ = {}
 
-        native_namespace = nw.get_native_namespace(X)
+        native_backend = nw.get_native_namespace(X)
 
         weights_column = self.weights_column
         if self.weights_column is None:
@@ -428,7 +428,7 @@ class GroupRareLevelsTransformer(BaseTransformer, WeightColumnMixin):
                 nw.new_series(
                     name=weights_column,
                     values=[1] * len(X),
-                    native_namespace=native_namespace,
+                    backend=native_backend,
                 ),
             )
 
@@ -834,14 +834,14 @@ class MeanResponseTransformer(
             WeightColumnMixin.check_weights_column(self, X, self.weights_column)
 
         else:
-            native_namespace = nw.get_native_namespace(X)
+            native_backend = nw.get_native_namespace(X)
 
             weights_column = "dummy_weights_column"
             X = X.with_columns(
                 nw.new_series(
                     name=weights_column,
                     values=[1] * len(X),
-                    backend=native_namespace.__name__,
+                    backend=native_backend.__name__,
                 ),
             )
 

--- a/tubular/numeric.py
+++ b/tubular/numeric.py
@@ -1026,14 +1026,14 @@ class OneDKmeansTransformer(BaseNumericTransformer, DropOriginalMixin):
             **self.kmeans_kwargs,
         )
 
-        native_namespace = nw.get_native_namespace(X).__name__
+        native_backend = nw.get_native_namespace(X).__name__
         groups = kmeans.fit_predict(X.select(self.columns[0]).to_numpy())
 
         X = X.with_columns(
             nw.new_series(
                 name="groups",
                 values=np.copy(groups),
-                backend=native_namespace,
+                backend=native_backend,
             ),
         )
 
@@ -1066,7 +1066,7 @@ class OneDKmeansTransformer(BaseNumericTransformer, DropOriginalMixin):
         X = super().transform(X)
 
         X = nw.from_native(X)
-        native_namespace = nw.get_native_namespace(X).__name__
+        native_backend = nw.get_native_namespace(X).__name__
 
         groups = np.digitize(
             X.select(self.columns[0]).to_numpy().ravel(),
@@ -1078,7 +1078,7 @@ class OneDKmeansTransformer(BaseNumericTransformer, DropOriginalMixin):
             nw.new_series(
                 name=self.new_column_name,
                 values=groups,
-                backend=native_namespace,
+                backend=native_backend,
             ),
         )
         return self.drop_original_column(X, self.drop_original, self.columns[0])


### PR DESCRIPTION
Addressing #412 

`native_namespace` has been deprecated so changing to the recommended` backend` throughout the package where not used already.

In many places we set the variable `native_namespace = nw.get_native_namespace(df) ` which I have replaced with `native_backend`
