### PR TITLE
beartype BaseTransformer init

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,8 +29,7 @@ Changed
 - narwhalified DateDiffLeapYearTransformer.
 - narwhalified MappingTransformer `#374 <https://github.com/azukds/tubular/issues/374>_`
 - added OneDKmeansTransformer. `#406 <https://github.com/azukds/tubular/issues/406>_`
-- placeholder 
-- placeholder
+- beartype typechecking for BaseTransformer init method `#417 <https://github.com/azukds/tubular/issues/417>_`
 - placeholder
 
 1.4.2 (18/03/2025)

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -9,6 +9,7 @@ import pandas as pd
 import polars as pl
 import pytest
 import sklearn.base as b
+from beartype.roar import BeartypeCallHintParamViolation
 
 from tests.utils import assert_frame_equal_dispatch
 
@@ -48,8 +49,7 @@ class GenericInitTests:
         """Test an error is raised if verbose is not specified as a bool."""
 
         with pytest.raises(
-            TypeError,
-            match=f"{self.transformer_name}: verbose must be a bool",
+            BeartypeCallHintParamViolation,
         ):
             uninitialized_transformers[self.transformer_name](
                 verbose=non_bool,
@@ -92,16 +92,20 @@ class ColumnStrListInitTests(GenericInitTests):
         args["columns"] = [non_string, non_string]
 
         with pytest.raises(
-            TypeError,
-            match=re.escape(
-                f"{self.transformer_name}: each element of columns should be a single (string) column name",
-            ),
+            BeartypeCallHintParamViolation,
         ):
             uninitialized_transformers[self.transformer_name](**args)
 
     @pytest.mark.parametrize(
         "non_string_or_list",
-        [1, True, {"a": 1}, None, np.inf, np.nan],
+        [
+            1,
+            True,
+            {"a": 1},
+            None,
+            np.inf,
+            np.nan,
+        ],
     )
     def test_columns_non_string_or_list_error(
         self,
@@ -115,10 +119,7 @@ class ColumnStrListInitTests(GenericInitTests):
         args["columns"] = non_string_or_list
 
         with pytest.raises(
-            TypeError,
-            match=re.escape(
-                f"{self.transformer_name}: columns must be a string or list with the columns to be pre-processed (if specified)",
-            ),
+            BeartypeCallHintParamViolation,
         ):
             uninitialized_transformers[self.transformer_name](**args)
 

--- a/tests/imputers/test_ArbitraryImputer.py
+++ b/tests/imputers/test_ArbitraryImputer.py
@@ -34,16 +34,6 @@ def impute_df_with_several_types(library="pandas"):
 class TestInit(ColumnStrListInitTests):
     """Generic tests for transformer.init()."""
 
-    # overload some inherited arg tests that have been replaced by beartype
-    def test_columns_non_string_or_list_error(self):
-        pass
-
-    def test_columns_list_element_error(self):
-        pass
-
-    def test_verbose_non_bool_error(self):
-        pass
-
     @classmethod
     def setup_class(cls):
         cls.transformer_name = "ArbitraryImputer"

--- a/tests/mapping/test_BaseMappingTransformer.py
+++ b/tests/mapping/test_BaseMappingTransformer.py
@@ -68,9 +68,6 @@ class BaseMappingTransformerInitTests(GenericInitTests):
             actual == expected
         ), f"return_dtypes attr not inferred as expected, expected {expected} but got {actual}"
 
-    def test_verbose_non_bool_error(self):
-        "overload this test, as transformer has been converted to beartype"
-
 
 class BaseMappingTransformerTransformTests(GenericTransformTests):
     """

--- a/tests/nominal/test_MeanResponseTransformer.py
+++ b/tests/nominal/test_MeanResponseTransformer.py
@@ -182,14 +182,6 @@ class TestInit(ColumnStrListInitTests, WeightColumnInitMixinTests):
         cls.transformer_name = "MeanResponseTransformer"
 
     # overload inherited arg tests that have been replaced by beartype
-    def test_columns_non_string_or_list_error(self):
-        pass
-
-    def test_columns_list_element_error(self):
-        pass
-
-    def test_verbose_non_bool_error(self):
-        pass
 
     def test_weight_arg_errors(self):
         pass

--- a/tests/numeric/test_OneDKmeansTransformer.py
+++ b/tests/numeric/test_OneDKmeansTransformer.py
@@ -25,9 +25,6 @@ class TestInit(
     def test_drop_column_arg_errors(self):
         pass
 
-    def test_verbose_non_bool_error(self):
-        pass
-
     def test_clone(self):
         pass
 

--- a/tests/strings/test_SeriesStrMethodTransformer.py
+++ b/tests/strings/test_SeriesStrMethodTransformer.py
@@ -3,6 +3,7 @@ import re
 import numpy as np
 import pytest
 import test_aide as ta
+from beartype.roar import BeartypeCallHintParamViolation
 
 import tests.test_data as d
 from tests.base_tests import (
@@ -38,10 +39,7 @@ class TestInit(ColumnStrListInitTests, NewColumnNameInitMixintests):
         args["columns"] = [non_string]
 
         with pytest.raises(
-            TypeError,
-            match=re.escape(
-                f"{self.transformer_name}: each element of columns should be a single (string) column name",
-            ),
+            BeartypeCallHintParamViolation,
         ):
             uninitialized_transformers[self.transformer_name](**args)
 

--- a/tubular/base.py
+++ b/tubular/base.py
@@ -5,10 +5,11 @@ from. These transformers contain key checks to be applied in all cases.
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 import narwhals as nw
 import pandas as pd
+from beartype import beartype
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
 
@@ -61,16 +62,13 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
         """Method that returns the name of the current class when called."""
         return type(self).__name__
 
+    @beartype
     def __init__(
         self,
-        columns: list[str] | str,
-        copy: bool | None = None,
+        columns: Union[list[str], str],
+        copy: Union[bool, None] = None,
         verbose: bool = False,
     ) -> None:
-        if not isinstance(verbose, bool):
-            msg = f"{self.classname()}: verbose must be a bool"
-            raise TypeError(msg)
-
         if copy is not None:
             warnings.warn(
                 "copy argument no longer used and will be deprecated in a future release",
@@ -92,16 +90,7 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
                 msg = f"{self.classname()}: columns has no values"
                 raise ValueError(msg)
 
-            for c in columns:
-                if not isinstance(c, str):
-                    msg = f"{self.classname()}: each element of columns should be a single (string) column name"
-                    raise TypeError(msg)
-
             self.columns = columns
-
-        else:
-            msg = f"{self.classname()}: columns must be a string or list with the columns to be pre-processed (if specified)"
-            raise TypeError(msg)
 
         self.copy = copy
 


### PR DESCRIPTION
adds beartyping to init of BaseTransformer.

This will close issues #399 #410 as beartyping the BaseTransformer init means we no longer need to override the tests in child test classes.

I have changed the existing tests of type checking to only check that a BeartypeCallHintParamViolation is raised but with no specific message matching.  This is to avoid both some complexity required in handling parametrized tests and to avoid our tests breaking due to minor changes in the error messages raised by beartype.  Arguably testing this should be out of scope for this project anyway.

beartyping init was simple but it seems that doing the same for fit or any mehtod with a frameT arg seems to be more difficult, raising the error:

beartype.roar.BeartypeCallHintForwardRefException: Forward reference "FrameT" unimportable from module "tubular.base".

propose looking into this with a new issue and keeping this PR to porting init.

Other follow on work could include:

Removing some mixins or methods which only really exist for type checking:
- NewColumnNameMixin
- SeparatorColumnMixin
- TwoColumnMixin(?)
- check_and_set_weight method
- set_drop_original method


