### PR TITLE
fixed mapping transformer issues with bool and null mappings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,18 @@ Each individual change should have a link to the pull request after the descript
 
 Changed
 ^^^^^^^
+- narwhalified ToDatetimeTransformer. Also made some usability improvements, e.g. to accept multiple columns `#379 <https://github.com/azukds/tubular/issues/379>_`
+- fixed bug with MappingTransformer, BaseMappingTransformerMixin where nullable boolean mappings were being converted to non-nullable booleans
+- Working on above, found additional bug with mapping null values. 
+Considered removing this functionality, but it is actually needed for 
+inverse pipelines. Changed this part of logic to work more like an imputer.
+- placeholder 
+
+1.4.3 (02/06/2025)
+------------------
+
+Changed
+^^^^^^^
 - narwhalified ArbitraryImputer `#315 <https://github.com/azukds/tubular/issues/315>_`
 - narwhalified BetweenDatesTransformer `#377 <https://github.com/azukds/tubular/issues/377>_`
 - feat: narwhalified MeanResponseTransformer `373 <https://github.com/azukds/tubular/issues/373>_`

--- a/tests/_utils/test_new_narwhals_series_with_best_pandas_types.py
+++ b/tests/_utils/test_new_narwhals_series_with_best_pandas_types.py
@@ -1,0 +1,115 @@
+import narwhals as nw
+import pandas as pd
+import polars as pl
+import pytest
+from pandas.api.types import CategoricalDtype
+from pandas.testing import assert_series_equal as assert_series_equal_pandas
+from polars.testing import assert_series_equal as assert_series_equal_polars
+
+from tubular._utils import (
+    new_narwhals_series_with_best_pandas_types,  # noqa: PLC2701, importing from private module to test
+)
+
+
+class TestNewNarwhalsSeriesWithBestPandasTypes:
+    @pytest.mark.parametrize(
+        ("values", "dtype"),
+        [
+            ([1, 0, 0], "Int64"),
+            ([1, 0, None], "Float64"),
+            (["a", "b", None], "String"),
+            ((["a", None, "c"], "Categorical")),
+            ([True, False, True], "Boolean"),
+            ([True, False, None], "Boolean"),
+        ],
+    )
+    def test_polars_unaffected(self, values, dtype):
+        "test that polars Series are initialised as usual"
+        name = "a"
+        output = new_narwhals_series_with_best_pandas_types(
+            name=name,
+            values=values,
+            backend="polars",
+            dtype=getattr(nw, dtype),
+        )
+
+        expected = pl.Series(
+            name=name,
+            values=values,
+            dtype=getattr(pl, dtype),
+        )
+
+        assert_series_equal_polars(expected, output.to_native())
+
+    @pytest.mark.parametrize(
+        ("values", "polars_dtype", "expected_pandas_dtype"),
+        [
+            ([1, 0, 0], "Int64", "Int64"),
+            ([1, 0, None], "Float64", "Float64"),
+            ([True, False, True], "Boolean", "boolean"),
+            ([True, False, None], "Boolean", "boolean"),
+        ],
+    )
+    def test_pandas_output(self, values, polars_dtype, expected_pandas_dtype):
+        "test that polars Series are initialised as usual"
+        name = "a"
+        output = new_narwhals_series_with_best_pandas_types(
+            name=name,
+            values=values,
+            backend="pandas",
+            dtype=getattr(nw, polars_dtype),
+        )
+
+        expected = pd.Series(
+            name=name,
+            data=values,
+            dtype=expected_pandas_dtype,
+        )
+
+        assert_series_equal_pandas(expected, output.to_native())
+
+    def test_pandas_output_category(self):
+        """test that polars Series are initialised as usual
+        for category type which requires special handling"""
+        name = "a"
+        categories = ["a", "b", "c"]
+        cat_type = CategoricalDtype(
+            pd.Series(data=categories, dtype="string"),
+            ordered=False,
+        )
+        output = new_narwhals_series_with_best_pandas_types(
+            name=name,
+            values=categories,
+            backend="pandas",
+            dtype=nw.Categorical,
+        )
+
+        expected = pd.Series(
+            name=name,
+            data=categories,
+            dtype=cat_type,
+        )
+
+        assert_series_equal_pandas(expected, output.to_native())
+
+    def test_pandas_output_string(self):
+        """test that polars Series are initialised as usual
+        for string type which requires special handling"""
+        name = "a"
+        values = ["a", None, "c"]
+        output = new_narwhals_series_with_best_pandas_types(
+            name=name,
+            values=values,
+            backend="pandas",
+            dtype=nw.String,
+        )
+
+        expected = pd.Series(
+            name=name,
+            data=values,
+            dtype="string",
+        ).fillna(pd.NA)
+
+        print(expected)
+        print(output.to_native())
+        assert_series_equal_pandas(expected, output.to_native())

--- a/tests/_utils/test_new_narwhals_series_with_best_pandas_types.py
+++ b/tests/_utils/test_new_narwhals_series_with_best_pandas_types.py
@@ -110,6 +110,4 @@ class TestNewNarwhalsSeriesWithBestPandasTypes:
             dtype="string",
         ).fillna(pd.NA)
 
-        print(expected)
-        print(output.to_native())
         assert_series_equal_pandas(expected, output.to_native())

--- a/tests/_utils/test_new_narwhals_series_with_best_pandas_types.py
+++ b/tests/_utils/test_new_narwhals_series_with_best_pandas_types.py
@@ -7,7 +7,7 @@ from pandas.testing import assert_series_equal as assert_series_equal_pandas
 from polars.testing import assert_series_equal as assert_series_equal_polars
 
 from tubular._utils import (
-    new_narwhals_series_with_best_pandas_types,  # noqa: PLC2701, importing from private module to test
+    new_narwhals_series_with_optimal_pandas_types,  # noqa: PLC2701, importing from private module to test
 )
 
 
@@ -26,7 +26,7 @@ class TestNewNarwhalsSeriesWithBestPandasTypes:
     def test_polars_unaffected(self, values, dtype):
         "test that polars Series are initialised as usual"
         name = "a"
-        output = new_narwhals_series_with_best_pandas_types(
+        output = new_narwhals_series_with_optimal_pandas_types(
             name=name,
             values=values,
             backend="polars",
@@ -53,7 +53,7 @@ class TestNewNarwhalsSeriesWithBestPandasTypes:
     def test_pandas_output(self, values, polars_dtype, expected_pandas_dtype):
         "test that polars Series are initialised as usual"
         name = "a"
-        output = new_narwhals_series_with_best_pandas_types(
+        output = new_narwhals_series_with_optimal_pandas_types(
             name=name,
             values=values,
             backend="pandas",
@@ -77,7 +77,7 @@ class TestNewNarwhalsSeriesWithBestPandasTypes:
             pd.Series(data=categories, dtype="string"),
             ordered=False,
         )
-        output = new_narwhals_series_with_best_pandas_types(
+        output = new_narwhals_series_with_optimal_pandas_types(
             name=name,
             values=categories,
             backend="pandas",
@@ -97,7 +97,7 @@ class TestNewNarwhalsSeriesWithBestPandasTypes:
         for string type which requires special handling"""
         name = "a"
         values = ["a", None, "c"]
-        output = new_narwhals_series_with_best_pandas_types(
+        output = new_narwhals_series_with_optimal_pandas_types(
             name=name,
             values=values,
             backend="pandas",

--- a/tests/mapping/test_BaseMappingTransformMixin.py
+++ b/tests/mapping/test_BaseMappingTransformMixin.py
@@ -1,6 +1,7 @@
 import copy
 import re
 
+import narwhals as nw
 import pandas as pd
 import polars as pl
 import pytest
@@ -13,7 +14,7 @@ from tests.base_tests import (
     OtherBaseBehaviourTests,
 )
 from tests.utils import assert_frame_equal_dispatch, dataframe_init_dispatch
-from tubular.mapping import BaseMappingTransformMixin
+from tubular.mapping import BaseMappingTransformer, BaseMappingTransformMixin
 
 # Note there are no tests that need inheriting from this file as the only difference is an expected transform output
 
@@ -73,10 +74,85 @@ class TestTransform(GenericTransformTests):
         if not transformer.polars_compatible and isinstance(df, pl.DataFrame):
             return
 
-        transformer.mappings = mapping
-        transformer.return_dtypes = {"a": "String", "b": "Int64"}
+        return_dtypes = {"a": "String", "b": "Int64"}
+
+        base_mapping_transformer = BaseMappingTransformer(
+            mappings=mapping,
+            return_dtypes=return_dtypes,
+        )
+
+        transformer.mappings = base_mapping_transformer.mappings
+        transformer.return_dtypes = base_mapping_transformer.return_dtypes
+        transformer.null_mappings = base_mapping_transformer.null_mappings
 
         df_transformed = transformer.transform(df)
+
+        assert_frame_equal_dispatch(expected, df_transformed)
+
+    @pytest.mark.parametrize("library", ["pandas", "polars"])
+    def test_expected_output_boolean(self, library):
+        """Test that output is as expected for tricky bool case."""
+
+        df_dict = {
+            "a": [None, 0, 1, None, 0],
+            "b": [True, False, None, True, False],
+            "c": [None, 0, 0, None, 1],
+            "d": [True, None, None, True, False],
+        }
+
+        df = dataframe_init_dispatch(dataframe_dict=df_dict, library=library)
+
+        mapping = {
+            "a": {0: False, 1: True},
+            "b": {False: 0, True: 1},
+            "c": {0: False, None: False, 1: True},
+            "d": {False: 1, True: 0, None: 1},
+        }
+
+        return_dtypes = {
+            "a": "Boolean",
+            "b": "Float64",
+            "c": "Boolean",
+            "d": "Int64",
+        }
+
+        expected_dict = {
+            "a": [None, False, True, None, False],
+            "b": [1, 0, None, 1, 0],
+            "c": [False, False, False, False, True],
+            "d": [0, 1, 1, 0, 1],
+        }
+
+        expected = dataframe_init_dispatch(
+            dataframe_dict=expected_dict,
+            library=library,
+        )
+
+        base_mapping_transformer = BaseMappingTransformer(
+            mappings=mapping,
+            return_dtypes=return_dtypes,
+        )
+
+        transformer = BaseMappingTransformMixin(columns=["c"])
+
+        # if transformer is not yet polars compatible, skip this test
+        if not transformer.polars_compatible and isinstance(df, pl.DataFrame):
+            return
+
+        transformer.mappings = base_mapping_transformer.mappings
+
+        transformer.return_dtypes = base_mapping_transformer.return_dtypes
+
+        transformer.null_mappings = base_mapping_transformer.null_mappings
+
+        df_transformed = transformer.transform(df)
+
+        # convert bool type to pyarrow
+        if library == "pandas":
+            expected = nw.from_native(expected)
+            expected = expected.with_columns(nw.maybe_convert_dtypes(expected["c"]))
+            expected = expected.with_columns(nw.maybe_convert_dtypes(expected["a"]))
+            expected = expected.to_native()
 
         assert_frame_equal_dispatch(expected, df_transformed)
 
@@ -91,11 +167,19 @@ class TestTransform(GenericTransformTests):
         if not transformer.polars_compatible and isinstance(df, pl.DataFrame):
             return
 
-        transformer.mappings = mapping
-        transformer.return_dtypes = {
+        return_dtypes = {
             "a": "String",
             "b": "Int64",
         }
+
+        base_mapping_transformer = BaseMappingTransformer(
+            mappings=mapping,
+            return_dtypes=return_dtypes,
+        )
+
+        transformer.mappings = base_mapping_transformer.mappings
+        transformer.return_dtypes = base_mapping_transformer.return_dtypes
+        transformer.null_mappings = base_mapping_transformer.null_mappings
 
         transformer.transform(df)
 
@@ -121,10 +205,18 @@ class TestTransform(GenericTransformTests):
         if not transformer.polars_compatible and isinstance(df, pl.DataFrame):
             return
 
-        transformer.mappings = mapping
-        transformer.return_dtypes = {
+        return_dtypes = {
             "a": "String",
         }
+
+        base_mapping_transformer = BaseMappingTransformer(
+            mappings=mapping,
+            return_dtypes=return_dtypes,
+        )
+
+        transformer.mappings = base_mapping_transformer.mappings
+        transformer.return_dtypes = base_mapping_transformer.return_dtypes
+        transformer.null_mappings = base_mapping_transformer.null_mappings
 
         x_fitted = transformer.fit(df, df["c"])
 
@@ -145,8 +237,16 @@ class TestTransform(GenericTransformTests):
         if not transformer.polars_compatible and isinstance(df, pl.DataFrame):
             return
 
-        transformer.mappings = mapping
-        transformer.return_dtypes = {"a": "String"}
+        return_dtypes = {"a": "String"}
+
+        base_mapping_transformer = BaseMappingTransformer(
+            mappings=mapping,
+            return_dtypes=return_dtypes,
+        )
+
+        transformer.mappings = base_mapping_transformer.mappings
+        transformer.return_dtypes = base_mapping_transformer.return_dtypes
+        transformer.null_mappings = base_mapping_transformer.null_mappings
 
         transformer = transformer.fit(df, df["c"])
 
@@ -170,8 +270,16 @@ class TestTransform(GenericTransformTests):
         if not transformer.polars_compatible and isinstance(df, pl.DataFrame):
             return
 
-        transformer.mappings = mapping
-        transformer.return_dtypes = {"a": "String", "b": "Int64"}
+        return_dtypes = {"a": "String", "b": "Int64"}
+
+        base_mapping_transformer = BaseMappingTransformer(
+            mappings=mapping,
+            return_dtypes=return_dtypes,
+        )
+
+        transformer.mappings = base_mapping_transformer.mappings
+        transformer.return_dtypes = base_mapping_transformer.return_dtypes
+        transformer.null_mappings = base_mapping_transformer.null_mappings
 
         transformer = transformer.fit(df, df["c"])
 
@@ -193,14 +301,22 @@ class TestTransform(GenericTransformTests):
         """Test that the original (pandas) dataframe index is not transformed when transform method used."""
 
         df = minimal_dataframe_lookup[self.transformer_name]
+
+        df = nw.from_native(copy.deepcopy(df))
+        df = nw.maybe_convert_dtypes(df).to_native()
+
         transformer = initialized_transformers[self.transformer_name]
 
-        # if transformer is not yet polars compatible, skip this test
-        if not transformer.polars_compatible and isinstance(df, pl.DataFrame):
-            return
+        return_dtypes = {"a": "String", "b": "String"}
 
-        transformer.mappings = mapping
-        transformer.return_dtypes = {"a": "String", "b": "String"}
+        base_mapping_transformer = BaseMappingTransformer(
+            mappings=mapping,
+            return_dtypes=return_dtypes,
+        )
+
+        transformer.mappings = base_mapping_transformer.mappings
+        transformer.return_dtypes = base_mapping_transformer.return_dtypes
+        transformer.null_mappings = base_mapping_transformer.null_mappings
 
         # update to abnormal index
         df.index = [2 * i for i in df.index]

--- a/tests/mapping/test_BaseMappingTransformMixin.py
+++ b/tests/mapping/test_BaseMappingTransformMixin.py
@@ -109,7 +109,8 @@ class TestTransform(GenericTransformTests):
             'a': [
                 1,
                 0,
-                None # mapping merge has failed on None
+                None # mapping merge has failed on None,
+                # resulting in None instead of 0
             ]
             }
         )
@@ -128,7 +129,7 @@ class TestTransform(GenericTransformTests):
                 True,
                 False,
                 # when the mapping values are put into bool series
-                # the none value is converted to False
+                # the none value is converted to False, instead of None
                 False,
 
             ]

--- a/tests/mapping/test_MappingTransformer.py
+++ b/tests/mapping/test_MappingTransformer.py
@@ -224,8 +224,52 @@ class TestTransform(BaseMappingTransformerTransformTests):
             x.transform(df)
 
     @pytest.mark.parametrize("library", ["pandas", "polars"])
-    def test_expected_output_boolean(self, library):
-        """Test that output is as expected for tricky bool case."""
+    def test_expected_output_boolean_with_nulls(self, library):
+        """Test that output is as expected for tricky bool cases:
+        e.g. mapping {True:1, False:0, None: 0}, potential causes of failure:
+            - None being cast to False when these values are inserted into bool series
+            - None mapping failing, as mapping logic relies on merging and None->None values
+            will not merge
+
+        Example failure 1:
+        df=pd.DataFrame({'a': [True, False, None]})
+        mappings={True:1, False:0, None:0}
+        return_dtypes={'a': 'Int8'}
+        mapping_transformer=MappingTransformer(mappings, return_dtypes)
+
+        mapping_transformer.transform(df)->
+        pd.DataFrame(
+            {
+            'a': [
+                1,
+                0,
+                None # mapping merge has failed on None
+            ]
+            }
+        )
+
+        ---------
+        Example Failure 2
+        df=pd.DataFrame({'a': [1, 0, -1]})
+        mappings={1:True, 0:False, -1:None}
+        return_dtypes={'a': 'Int8'}
+        mapping_transformer=MappingTransformer(mappings, return_dtypes)
+
+        mapping_transformer.transform(df)->
+        pd.DataFrame(
+            {
+            'a': [
+                True,
+                False,
+                # when the mapping values are put into bool series
+                # the none value is converted to False
+                False,
+
+            ]
+            }
+        )
+
+        """
 
         df_dict = {
             "a": [None, 0, 1, None, 0],

--- a/tests/mapping/test_MappingTransformer.py
+++ b/tests/mapping/test_MappingTransformer.py
@@ -243,7 +243,8 @@ class TestTransform(BaseMappingTransformerTransformTests):
             'a': [
                 1,
                 0,
-                None # mapping merge has failed on None
+                None # mapping merge has failed on None,
+                #resulting in None instead of 0
             ]
             }
         )
@@ -262,7 +263,7 @@ class TestTransform(BaseMappingTransformerTransformTests):
                 True,
                 False,
                 # when the mapping values are put into bool series
-                # the none value is converted to False
+                # the none value is converted to False, instead of None
                 False,
 
             ]

--- a/tests/nominal/test_MeanResponseTransformer.py
+++ b/tests/nominal/test_MeanResponseTransformer.py
@@ -1252,6 +1252,7 @@ class TestTransform(GenericTransformTests):
         x.response_levels = level
         x.encoded_columns = list(x.mappings.keys())
         x.return_dtypes = {col: x.return_type for col in x.encoded_columns}
+        x.null_mappings = {col: None for col in x.encoded_columns}
 
         df_transformed = x.transform(df)
 

--- a/tests/nominal/test_NominalToIntegerTransformer.py
+++ b/tests/nominal/test_NominalToIntegerTransformer.py
@@ -128,6 +128,7 @@ class TestTransform(GenericNominalTransformTests):
             "a": {1: 0, 2: 1, 3: 2, 4: 3, 5: 4, 6: 5},
             "b": {"a": 0, "b": 1, "c": 2, "d": 3, "e": 4, "f": 5},
         }
+        x.null_mappings = {"a": None, "b": None}
 
         df_transformed = x.transform(df)
 

--- a/tests/nominal/test_OrdinalEncoderTransformer.py
+++ b/tests/nominal/test_OrdinalEncoderTransformer.py
@@ -188,6 +188,7 @@ class TestTransform(GenericTransformTests):
             "d": {1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6},
             "f": {False: 1, True: 2},
         }
+        x.null_mappings = {"b": None, "d": None, "f": None}
 
         df_transformed = x.transform(df)
 

--- a/tubular/_utils.py
+++ b/tubular/_utils.py
@@ -84,10 +84,11 @@ def new_narwhals_series_with_optimal_pandas_types(
     if backend == "pandas":
         series = pd.Series(name=name, data=values)
         series = nw.maybe_convert_dtypes(nw.from_native(series, allow_series=True))
-        # maybe_convert_dtype already handles object->string, casting
-        # again would convert back, so avoid
-        # also avoid directly casting back to object..
-        if dtype != nw.String and dtype != nw.Object and dtype != nw.Boolean:
+        # for int/float values, we may still want to cast to better type
+        # (e.g. int8)
+        # but for bool/str values, maybe_convert_types has already
+        # cast to improved typing, so avoid further casting for these
+        if dtype not in [nw.String, nw.Object, nw.Boolean]:
             series = series.cast(dtype)
 
     else:

--- a/tubular/_utils.py
+++ b/tubular/_utils.py
@@ -1,4 +1,9 @@
+from typing import Literal
+
+import narwhals as nw
 import pandas as pd
+from narwhals.typing import IntoDType
+from numpy.typing import ArrayLike
 
 
 def _assess_pandas_object_column(pandas_df: pd.DataFrame, col: str) -> tuple[str, str]:
@@ -46,3 +51,46 @@ def _assess_pandas_object_column(pandas_df: pd.DataFrame, col: str) -> tuple[str
     # we may wish to add more cases in future, but starting with these
 
     return pandas_col_type, polars_col_type
+
+
+def new_narwhals_series_with_best_pandas_types(
+    name: str,
+    values: ArrayLike,
+    backend: Literal["pandas", "polars"],
+    dtype: IntoDType,
+) -> nw.Series:
+    """wraps around nw.new_series to ensure that pandas doesn't default to non-nullable
+    types
+
+    Parameters
+    ----------
+    name:
+        name of new series
+
+    values:
+        values for new series
+
+    backend:
+        data processing package to use (pandas or polars)
+
+    dtype:
+        wanted narwhals dtype for output
+
+    Returns
+    ----------
+    nw.Series: new narwhals series
+    """
+
+    if backend == "pandas":
+        series = pd.Series(name=name, data=values)
+        series = nw.maybe_convert_dtypes(nw.from_native(series, allow_series=True))
+        # maybe_convert_dtype already handles object->string, casting
+        # again would convert back, so avoid
+        # also avoid directly casting back to object..
+        if dtype != nw.String and dtype != nw.Object and dtype != nw.Boolean:
+            series = series.cast(dtype)
+
+    else:
+        series = nw.new_series(name=name, values=values, backend=backend, dtype=dtype)
+
+    return series

--- a/tubular/_utils.py
+++ b/tubular/_utils.py
@@ -53,7 +53,7 @@ def _assess_pandas_object_column(pandas_df: pd.DataFrame, col: str) -> tuple[str
     return pandas_col_type, polars_col_type
 
 
-def new_narwhals_series_with_best_pandas_types(
+def new_narwhals_series_with_optimal_pandas_types(
     name: str,
     values: ArrayLike,
     backend: Literal["pandas", "polars"],

--- a/tubular/mapping.py
+++ b/tubular/mapping.py
@@ -12,7 +12,7 @@ import pandas as pd
 import polars as pl
 from beartype import beartype
 
-from tubular._utils import new_narwhals_series_with_best_pandas_types
+from tubular._utils import new_narwhals_series_with_optimal_pandas_types
 from tubular.base import BaseTransformer
 
 if TYPE_CHECKING:
@@ -208,14 +208,14 @@ class BaseMappingTransformMixin(BaseTransformer):
                 if dtypes[dtype_key] == nw.Categorical:
                     temp_dtypes[dtype_key] = nw.String
 
-            mappings_keys = new_narwhals_series_with_best_pandas_types(
+            mappings_keys = new_narwhals_series_with_optimal_pandas_types(
                 name=col,
                 values=list(mappings.keys()),
                 backend=native_backend.__name__,
                 dtype=temp_dtypes["keys"],
             )
 
-            mappings_values = new_narwhals_series_with_best_pandas_types(
+            mappings_values = new_narwhals_series_with_optimal_pandas_types(
                 name=new_col_values,
                 values=list(mappings.values()),
                 backend=native_backend.__name__,

--- a/tubular/mapping.py
+++ b/tubular/mapping.py
@@ -78,17 +78,17 @@ class BaseMappingTransformer(BaseTransformer):
 
         null_mappings = {col: None for col in mappings}
         for col in mappings:
-            null_count = 0
-            for key in mappings[col]:
-                if pd.isna(key):
-                    null_count += 1
-                    null_mappings[col] = mappings[col][key]
+            null_keys = [key for key in mappings[col] if pd.isna(key)]
 
-            if null_count > 1:
+            if len(null_keys) > 1:
                 multi_null_map_msg = f"Multiple mappings have been provided for null values in column {col}, transformer is set up to handle nan/None/NA as one"
                 raise ValueError(
                     multi_null_map_msg,
                 )
+
+            # Assign the mapping to the single null key if it exists
+            if len(null_keys) != 0:
+                null_mappings[col] = mappings[col][null_keys[0]]
 
         self.mappings = mappings
         self.null_mappings = null_mappings

--- a/tubular/mapping.py
+++ b/tubular/mapping.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import warnings
 from collections import OrderedDict
-from typing import TYPE_CHECKING, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 
 import narwhals as nw
 import numpy as np
@@ -12,6 +12,7 @@ import pandas as pd
 import polars as pl
 from beartype import beartype
 
+from tubular._utils import new_narwhals_series_with_best_pandas_types
 from tubular.base import BaseTransformer
 
 if TYPE_CHECKING:
@@ -67,7 +68,7 @@ class BaseMappingTransformer(BaseTransformer):
     @beartype
     def __init__(
         self,
-        mappings: dict[str, dict[Union[str, float, int], Union[str, float, int]]],
+        mappings: dict[str, dict[Any, Any]],
         return_dtypes: Union[dict[str, RETURN_DTYPES], None] = None,
         **kwargs: Optional[bool],
     ) -> None:
@@ -75,7 +76,22 @@ class BaseMappingTransformer(BaseTransformer):
             msg = f"{self.classname()}: mappings has no values"
             raise ValueError(msg)
 
+        null_mappings = {col: None for col in mappings}
+        for col in mappings:
+            null_count = 0
+            for key in mappings[col]:
+                if pd.isna(key):
+                    null_count += 1
+                    null_mappings[col] = mappings[col][key]
+
+            if null_count > 1:
+                multi_null_map_msg = f"Multiple mappings have been provided for null values in column {col}, transformer is set up to handle nan/None/NA as one"
+                raise ValueError(
+                    multi_null_map_msg,
+                )
+
         self.mappings = mappings
+        self.null_mappings = null_mappings
 
         columns = list(mappings.keys())
 
@@ -148,7 +164,7 @@ class BaseMappingTransformMixin(BaseTransformer):
             Transformed input X with levels mapped accoriding to mappings dict.
 
         """
-        self.check_is_fitted(["mappings", "return_dtypes"])
+        self.check_is_fitted(["mappings", "return_dtypes", "null_mappings"])
 
         X = nw.from_native(super().transform(X))
         native_backend = nw.get_native_namespace(X)
@@ -156,7 +172,7 @@ class BaseMappingTransformMixin(BaseTransformer):
         # will do a join further down, which does not preserve index
         # polars does not care about this, but pandas does,
         # so need to handle a bit carefully
-        if nw.get_native_namespace(X).__name__ == "pandas":
+        if native_backend.__name__ == "pandas":
             index = nw.to_native(X).index
 
         # pull out column order to preserve
@@ -167,22 +183,64 @@ class BaseMappingTransformMixin(BaseTransformer):
 
             # TODO - update this logic once narwhals implements map_dict
             # differentiate between unmapped cols and cols mapped to null
-            # by including unmapped cols
+            # by including unmapped cols mapped to self
             unique = X.get_column(col).unique()
-            mappings = {key: mappings.get(key, key) for key in unique}
-
+            mappings = {
+                key: mappings.get(key, key)
+                for key in unique
+                # nulls are handled separately at the end,
+                # treated as imputations
+                if not pd.isna(key)
+            }
             new_col_values = f"new_{col}_values"
+
+            # have to be careful at each stage to avoid pandas
+            # default non-nullable types
+            dtypes = {}
+            dtypes["keys"] = X.get_column(col).dtype
+            dtypes["values"] = getattr(nw, self.return_dtypes[col])
+
+            # from_dict also appears to struggle with category dtypes
+            # so convert to string and back again later
+            temp_dtypes = {}
+            for dtype_key in ["keys", "values"]:
+                temp_dtypes[dtype_key] = dtypes[dtype_key]
+                if dtypes[dtype_key] == nw.Categorical:
+                    temp_dtypes[dtype_key] = nw.String
+
+            mappings_keys = new_narwhals_series_with_best_pandas_types(
+                name=col,
+                values=list(mappings.keys()),
+                backend=native_backend.__name__,
+                dtype=temp_dtypes["keys"],
+            )
+
+            mappings_values = new_narwhals_series_with_best_pandas_types(
+                name=new_col_values,
+                values=list(mappings.values()),
+                backend=native_backend.__name__,
+                dtype=temp_dtypes["values"],
+            )
+
             mappings_df = nw.from_dict(
                 {
-                    col: list(mappings.keys()),
-                    new_col_values: list(mappings.values()),
-                },
-                schema={
-                    col: X.get_column(col).dtype,
-                    new_col_values: getattr(nw, self.return_dtypes[col]),
+                    col: mappings_keys,
+                    new_col_values: mappings_values,
                 },
                 backend=native_backend,
             )
+
+            # bring back category types, and keep forcing better bool type
+            for dtype_key, col_name in zip(["keys", "values"], [col, new_col_values]):
+                if dtypes[dtype_key] == nw.Categorical:
+                    mappings_df = mappings_df.with_columns(
+                        nw.col(col_name).cast(nw.Categorical),
+                    )
+
+                if self.return_dtypes[col] == "Boolean":
+                    mappings_df = mappings_df.with_columns(
+                        nw.maybe_convert_dtypes(mappings_df[col_name]),
+                    )
 
             X = (
                 X.join(
@@ -193,6 +251,13 @@ class BaseMappingTransformMixin(BaseTransformer):
                 .drop(col)
                 .rename({new_col_values: col})
             )
+
+            # null keys are not joined on, so just fill nulls at end
+            if self.null_mappings[col] is not None:
+                X = X.with_columns(nw.col(col).fill_null(self.null_mappings[col]))
+                X = X.with_columns(
+                    nw.col(col).cast(getattr(nw, self.return_dtypes[col])),
+                )
 
         # restore original index for pandas
         if nw.get_native_namespace(X).__name__ == "pandas":

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -12,7 +12,7 @@ from beartype import beartype
 
 from tubular.base import BaseTransformer
 from tubular.imputers import MeanImputer, MedianImputer
-from tubular.mapping import BaseMappingTransformMixin
+from tubular.mapping import BaseMappingTransformer, BaseMappingTransformMixin
 from tubular.mixins import DropOriginalMixin, SeparatorColumnMixin, WeightColumnMixin
 
 if TYPE_CHECKING:
@@ -169,6 +169,17 @@ class NominalToIntegerTransformer(BaseNominalTransformer, BaseMappingTransformMi
                 raise ValueError(
                     msg,
                 )
+
+        # use BaseMappingTransformer init to process args
+        # extract null_mappings from mappings etc
+        base_mapping_transformer = BaseMappingTransformer(
+            mappings=self.mappings,
+            return_dtypes=self.return_dtypes,
+        )
+
+        self.mappings = base_mapping_transformer.mappings
+        self.null_mappings = base_mapping_transformer.null_mappings
+        self.return_dtypes = base_mapping_transformer.return_dtypes
 
         return self
 
@@ -919,6 +930,17 @@ class MeanResponseTransformer(
         # this is used to cast the narwhals mapping df, so uses narwhals types
         self.return_dtypes = {col: self.return_type for col in self.encoded_columns}
 
+        # use BaseMappingTransformer init to process args
+        # extract null_mappings from mappings etc
+        base_mapping_transformer = BaseMappingTransformer(
+            mappings=self.mappings,
+            return_dtypes=self.return_dtypes,
+        )
+
+        self.mappings = base_mapping_transformer.mappings
+        self.null_mappings = base_mapping_transformer.null_mappings
+        self.return_dtypes = base_mapping_transformer.return_dtypes
+
         self._fit_unseen_level_handling_dict(X_y, weights_column)
 
         return self
@@ -1221,6 +1243,17 @@ class OrdinalEncoderTransformer(
                 raise ValueError(
                     msg,
                 )
+
+        # use BaseMappingTransformer init to process args
+        # extract null_mappings from mappings etc
+        base_mapping_transformer = BaseMappingTransformer(
+            mappings=self.mappings,
+            return_dtypes=self.return_dtypes,
+        )
+
+        self.mappings = base_mapping_transformer.mappings
+        self.null_mappings = base_mapping_transformer.null_mappings
+        self.return_dtypes = base_mapping_transformer.return_dtypes
 
         return self
 


### PR DESCRIPTION
mapping transformers were struggling with mappings containing bools/nulls, this was due to:

- pandas crazy type handling for bools, resulting in nulls in bool cols being converted to False
- the merge mapping logic failing for null values, which were not being merged on

Updated logic to:
- carefully force pandas to use best bool type at each stage
- handle null mappings separately as imputations
    - considered removing null mappings altogether, but they are needed for inverse pipelines 

Example Failure Cases
Example failure 1:
df=pd.DataFrame({'a': [True, False, None]})
mappings={True:1, False:0, None:0}
return_dtypes={'a': 'Int8'}
mapping_transformer=MappingTransformer(mappings, return_dtypes)
mapping_transformer.transform(df)->
pd.DataFrame(
    {
    'a': [
        1,
        0,
        None # mapping merge has failed on None, resulting in None instead of 0
    ]
    }
)
---------
Example Failure 2
df=pd.DataFrame({'a': [1, 0, -1]})
mappings={1:True, 0:False, -1:None}
return_dtypes={'a': 'Int8'}
mapping_transformer=MappingTransformer(mappings, return_dtypes)
mapping_transformer.transform(df)->
pd.DataFrame(
  {
  'a': [
      True,
      False,
      # when the mapping values are put into bool series
      # the none value is converted to False, instead of None
      False,
  ]
  }
)