### PR TITLE
User warnings silenced and tests

### DIFF
--- a/tests/mapping/test_MappingTransformer.py
+++ b/tests/mapping/test_MappingTransformer.py
@@ -196,7 +196,11 @@ class TestTransform(BaseMappingTransformerTransformTests):
     def test_no_applicable_mapping(self, mapping, mapped_col, return_dtypes, library):
         df = d.create_df_1(library=library)
 
-        x = MappingTransformer(mappings=mapping, return_dtypes=return_dtypes)
+        x = MappingTransformer(
+            mappings=mapping,
+            return_dtypes=return_dtypes,
+            verbose=True,
+        )
 
         with pytest.warns(
             UserWarning,
@@ -215,7 +219,11 @@ class TestTransform(BaseMappingTransformerTransformTests):
     def test_excess_mapping_values(self, mapping, mapped_col, return_dtypes, library):
         df = d.create_df_1(library=library)
 
-        x = MappingTransformer(mappings=mapping, return_dtypes=return_dtypes)
+        x = MappingTransformer(
+            mappings=mapping,
+            return_dtypes=return_dtypes,
+            verbose=True,
+        )
 
         with pytest.warns(
             UserWarning,
@@ -319,6 +327,49 @@ class TestTransform(BaseMappingTransformerTransformTests):
         df_transformed = transformer.transform(df)
 
         assert_frame_equal_dispatch(expected, df_transformed)
+
+    @pytest.mark.parametrize("library", ["pandas", "polars"])
+    def test_warnings_issued_with_verbose_true(self, library):
+        """Test that warnings are issued when verbose is set to True."""
+        df = d.create_df_1(library=library)
+
+        mapping = {"a": {99: 99, 98: 98}, "b": {"z": "99", "y": "98"}}
+        return_dtypes = {"a": "Int32", "b": "String"}
+
+        transformer = MappingTransformer(
+            mappings=mapping,
+            return_dtypes=return_dtypes,
+            verbose=True,
+        )
+
+        with pytest.warns(
+            UserWarning,
+            match="MappingTransformer: No values from mapping for a exist in dataframe.",
+        ):
+            transformer.transform(df)
+
+        with pytest.warns(
+            UserWarning,
+            match="MappingTransformer: No values from mapping for b exist in dataframe.",
+        ):
+            transformer.transform(df)
+
+    @pytest.mark.parametrize("library", ["pandas", "polars"])
+    def test_warnings_silenced_with_verbose_false(self, library):
+        """Test that warnings are silenced when verbose is set to defualt value False."""
+        df = d.create_df_1(library=library)
+
+        mapping = {"a": {99: 99, 98: 98}, "b": {"z": "99", "y": "98"}}
+        return_dtypes = {"a": "Int32", "b": "String"}
+
+        transformer = MappingTransformer(mappings=mapping, return_dtypes=return_dtypes)
+
+        with pytest.warns(None) as record:
+            transformer.transform(df)
+
+        assert (
+            len(record) == 0
+        ), "Warnings were issued despite verbose being set to False."
 
 
 class TestOtherBaseBehaviour(OtherBaseBehaviourTests):

--- a/tests/mapping/test_MappingTransformer.py
+++ b/tests/mapping/test_MappingTransformer.py
@@ -1,3 +1,5 @@
+import warnings
+
 import narwhals as nw
 import pytest
 
@@ -364,12 +366,13 @@ class TestTransform(BaseMappingTransformerTransformTests):
 
         transformer = MappingTransformer(mappings=mapping, return_dtypes=return_dtypes)
 
-        with pytest.warns(None) as record:
-            transformer.transform(df)
-
-        assert (
-            len(record) == 0
-        ), "Warnings were issued despite verbose being set to False."
+        # Guidance from pytest to use followiong syntax rather than pytest.warns(None)
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                transformer.transform(df)
+        except Warning:
+            pytest.fail("Warnings were issued despite verbose being set to False.")
 
 
 class TestOtherBaseBehaviour(OtherBaseBehaviourTests):

--- a/tubular/mapping.py
+++ b/tubular/mapping.py
@@ -340,17 +340,18 @@ class MappingTransformer(BaseMappingTransformer, BaseMappingTransformMixin):
             values_to_be_mapped = set(self.mappings[col].keys())
             values_in_df = set(X.get_column(col).unique())
 
-            if len(values_to_be_mapped.intersection(values_in_df)) == 0:
-                warnings.warn(
-                    f"{self.classname()}: No values from mapping for {col} exist in dataframe.",
-                    stacklevel=2,
-                )
+            if self.verbose:
+                if len(values_to_be_mapped.intersection(values_in_df)) == 0:
+                    warnings.warn(
+                        f"{self.classname()}: No values from mapping for {col} exist in dataframe.",
+                        stacklevel=2,
+                    )
 
-            if len(values_to_be_mapped.difference(values_in_df)) > 0:
-                warnings.warn(
-                    f"{self.classname()}: There are values in the mapping for {col} that are not present in the dataframe",
-                    stacklevel=2,
-                )
+                if len(values_to_be_mapped.difference(values_in_df)) > 0:
+                    warnings.warn(
+                        f"{self.classname()}: There are values in the mapping for {col} that are not present in the dataframe",
+                        stacklevel=2,
+                    )
 
         return nw.from_native(BaseMappingTransformMixin.transform(self, X))
 


### PR DESCRIPTION
Have made use of the inherited attribute 'verbose' from the BaseImputer class in order to silence the large number of Mapping Imputer User warnings experienced from missing levels in date series. 

The Default Value is False, which may need reviewing, as this also silences the warning for missing mapping dictionaries which share the same logic and warning.