### PR TITLE
speed optimisations for base transformer and imputers file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,14 +16,6 @@ Subsections for each version can be one of the following;
 
 Each individual change should have a link to the pull request after the description of the change.
 
-1.4.6 (04/07/2025)
-------------------
-
-Changed
-^^^^^^^
-- Added deprecated warning for DateDiffLeapYearTransformer `#244 <https://github.com/azukds/tubular/issues/244>`
-- Added new units 'week', 'fornight', 'lunar_month', 'common_year' and 'custom_days' to DateDifferenceTransformer. The time component will be truncated for these units and for unit 'D'.
-
 1.4.5 (unreleased))
 ------------------
 
@@ -32,6 +24,15 @@ Changed
 - bugfix: updated env to make package importable, added basic test for this
 - feat: added BaseAggregationTransformer and AggregateRowOverColumnsTransformer classes in new aggregations module
 - narwhalified DatetimeSinusoidCalculator '#425 <https://github.com/azukds/tubular/issues/425>_' 
+- Added deprecated warning for DateDiffLeapYearTransformer `#244 <https://github.com/azukds/tubular/issues/244>`
+- Added new units 'week', 'fornight', 'lunar_month', 'common_year' and 'custom_days' to DateDifferenceTransformer. The time component will be truncated for these units and for unit 'D'.
+- feat: optimisation changes to BaseTransfomer and imputers file. Edited to reduce number of copies and type changes
+from to/from_native calls, and select/with_columns being called many times.
+- feat: added 'return_native' argument to BaseTransfomer to control whether native or narwhals types are returned,
+and limit type changes. Idea is for this to be rolled out across transformers.
+- feat: made creation of copies in BaseTransfomer optional, and default to False.
+- placeholder
+- placeholder
 - placeholder
 
 1.4.4 (24/06/2025)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ ignore = [
     "B905", # the below two rules seem to make changes that error for python3.9
     "UP038", 
     "PYI041", # clashes with beartype
+    "TCH001", # clashes with beartype
     ]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
@@ -131,7 +132,11 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 # Ignore `E402` (import violations) in all `__init__.py` file.
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["E402", "F401"]
-"tests/*" = ["ANN", "S101"]
+"tests/*" = [
+    "ANN",
+    "S101",
+    "PLC2701" # complains about private imports, which we test
+    ]
 
 [tool.ruff.lint.pyupgrade]
 keep-runtime-typing=true

--- a/tests/imputers/test_ArbitraryImputer.py
+++ b/tests/imputers/test_ArbitraryImputer.py
@@ -12,6 +12,7 @@ from tests.base_tests import (
     GenericFitTests,
     GenericTransformTests,
     OtherBaseBehaviourTests,
+    ReturnNativeTests,
 )
 from tests.imputers.test_BaseImputer import GenericImputerTransformTests
 from tubular.imputers import ArbitraryImputer
@@ -47,7 +48,11 @@ class TestFit(GenericFitTests):
         cls.transformer_name = "ArbitraryImputer"
 
 
-class TestTransform(GenericImputerTransformTests, GenericTransformTests):
+class TestTransform(
+    GenericImputerTransformTests,
+    GenericTransformTests,
+    ReturnNativeTests,
+):
     """Tests for transformer.transform."""
 
     @classmethod
@@ -145,6 +150,13 @@ class TestTransform(GenericImputerTransformTests, GenericTransformTests):
         df_transformed_nw = nw.from_native(df_transformed_native)
 
         expected_dtype = df_nw[column].dtype
+
+        native_namespace = nw.get_native_namespace(df_nw).__name__
+
+        # for pandas categorical are converted to enum
+        if col_type == "Categorical" and native_namespace == "pandas":
+            expected_dtype = nw.Enum
+
         actual_dtype = df_transformed_nw[column].dtype
         assert (
             actual_dtype == expected_dtype
@@ -158,7 +170,14 @@ class TestTransform(GenericImputerTransformTests, GenericTransformTests):
             ),
         )
 
-        u.assert_frame_equal_dispatch(expected.to_native(), df_transformed_native)
+        u.assert_frame_equal_dispatch(
+            expected.to_native(),
+            df_transformed_native,
+            # this turns off checks for category metadata like ordering
+            # this transformer will convert an unordered pd categorical to ordered
+            # so this is needed
+            check_categorical=False,
+        )
 
     @pytest.mark.parametrize("library", ["pandas", "polars"])
     @pytest.mark.parametrize(
@@ -263,6 +282,64 @@ class TestTransform(GenericImputerTransformTests, GenericTransformTests):
 
         u.assert_frame_equal_dispatch(expected.to_native(), df_transformed_native)
 
+    # have to overload this one, as has slightly different categorical type handling
+    @pytest.mark.parametrize(
+        ("library", "expected_df_3", "impute_values_dict"),
+        [
+            ("pandas", "pandas", {"b": "g", "c": "f"}),
+            ("polars", "polars", {"b": "g", "c": "f"}),
+        ],
+        indirect=["expected_df_3"],
+    )
+    def test_expected_output_3(
+        self,
+        library,
+        expected_df_3,
+        initialized_transformers,
+        impute_values_dict,
+    ):
+        """Test that transform is giving the expected output when applied to object and categorical columns."""
+        # Create the DataFrame using the library parameter
+        df2 = d.create_df_2(library=library)
+
+        # Initialize the transformer
+        transformer = initialized_transformers[self.transformer_name]
+
+        transformer.impute_values_ = impute_values_dict
+
+        if self.transformer_name == "ArbitraryImputer":
+            transformer.impute_value = "f"
+
+        transformer.columns = ["b", "c"]
+
+        # Transform the DataFrame
+        df_transformed = transformer.transform(df2)
+
+        # Check whole dataframes
+        u.assert_frame_equal_dispatch(
+            df_transformed,
+            expected_df_3,
+            # this turns off checks for category metadata like ordering
+            # this transformer will convert an unordered pd categorical to ordered
+            # so this is needed
+            check_categorical=False,
+        )
+        df2 = nw.from_native(df2)
+        expected_df_3 = nw.from_native(expected_df_3)
+
+        for i in range(len(df2)):
+            df_transformed_row = transformer.transform(df2[[i]].to_native())
+            df_expected_row = expected_df_3[[i]].to_native()
+
+            u.assert_frame_equal_dispatch(
+                df_transformed_row,
+                df_expected_row,
+                # this turns off checks for category metadata like ordering
+                # this transformer will convert an unordered pd categorical to ordered
+                # so this is needed
+                check_categorical=False,
+            )
+
     @pytest.mark.parametrize(
         ("library", "expected_df_4", "impute_values_dict"),
         [
@@ -298,13 +375,14 @@ class TestTransform(GenericImputerTransformTests, GenericTransformTests):
         u.assert_frame_equal_dispatch(
             df_transformed,
             expected_df_4,
+            # this turns off checks for category metadata like ordering
+            # this transformer will convert an unordered pd categorical to ordered
+            # so this is needed
+            check_categorical=False,
         )
         df2 = nw.from_native(df2)
         expected_df_4 = nw.from_native(expected_df_4)
 
-        # Check outcomes for single rows
-        # turn off type change errors to avoid having to type the single rows
-        transformer.error_on_type_change = False
         for i in range(len(df2)):
             df_transformed_row = transformer.transform(df2[[i]].to_native())
             df_expected_row = expected_df_4[[i]].to_native()
@@ -312,6 +390,10 @@ class TestTransform(GenericImputerTransformTests, GenericTransformTests):
             u.assert_frame_equal_dispatch(
                 df_transformed_row,
                 df_expected_row,
+                # this turns off checks for category metadata like ordering
+                # this transformer will convert an unordered pd categorical to ordered
+                # so this is needed
+                check_categorical=False,
             )
 
     @pytest.mark.parametrize("library", ["pandas", "polars"])
@@ -337,10 +419,12 @@ class TestTransform(GenericImputerTransformTests, GenericTransformTests):
 
         transformer = ArbitraryImputer(impute_value=1, columns=[column])
 
+        bad_types = dict(nw.from_native(df).select(nw.col(column)).schema.items())
+
         msg = re.escape(
             f"""
                 {self.transformer_name}: transformer can only handle Float/Int/Boolean/String/Categorical/Unknown type columns
-                but got columns with types {nw.from_native(df).select(nw.col(column)).schema}
+                but got columns with types {bad_types}
                 """,
         )
 

--- a/tests/imputers/test_BaseImputer.py
+++ b/tests/imputers/test_BaseImputer.py
@@ -150,9 +150,6 @@ class GenericImputerTransformTests:
         df2 = nw.from_native(df2)
         expected_df_1 = nw.from_native(expected_df_1)
 
-        # Check outcomes for single rows
-        # turn off type change errors to avoid having to type the single rows
-        transformer.error_on_type_change = False
         for i in range(len(df2)):
             df_transformed_row = transformer.transform(df2[[i]].to_native())
             df_expected_row = expected_df_1[[i]].to_native()
@@ -194,9 +191,6 @@ class GenericImputerTransformTests:
         df2 = nw.from_native(df2)
         expected_df_2 = nw.from_native(expected_df_2)
 
-        # Check outcomes for single rows
-        # turn off type change errors to avoid having to type the single rows
-        transformer.error_on_type_change = False
         for i in range(len(df2)):
             df_transformed_row = transformer.transform(df2[[i]].to_native())
             df_expected_row = expected_df_2[[i]].to_native()
@@ -246,9 +240,6 @@ class GenericImputerTransformTests:
         df2 = nw.from_native(df2)
         expected_df_3 = nw.from_native(expected_df_3)
 
-        # Check outcomes for single rows
-        # turn off type change errors to avoid having to type the single rows
-        transformer.error_on_type_change = False
         for i in range(len(df2)):
             df_transformed_row = transformer.transform(df2[[i]].to_native())
             df_expected_row = expected_df_3[[i]].to_native()
@@ -277,7 +268,7 @@ class GenericImputerTransformTests:
         impute_value,
         expected,
     ):
-        """Test that transform is giving the expected output when applied to object and categorical columns."""
+        """Test that transform is giving the expected output when imputation value is falsey."""
         # Create the DataFrame using the library parameter
         df_dict = {
             "a": [True, False, None],
@@ -295,12 +286,12 @@ class GenericImputerTransformTests:
         # Initialize the transformer
         transformer = initialized_transformers[self.transformer_name]
 
-        transformer.impute_values_ = {column: impute_value}
-
         if self.transformer_name == "ArbitraryImputer":
             transformer.impute_value = impute_value
 
         transformer.columns = [column]
+
+        transformer.impute_values_ = {col: impute_value for col in transformer.columns}
 
         expected_df_dict = {
             column: expected,

--- a/tests/imputers/test_MeanImputer.py
+++ b/tests/imputers/test_MeanImputer.py
@@ -6,6 +6,7 @@ from tests.base_tests import (
     GenericFitTests,
     GenericTransformTests,
     OtherBaseBehaviourTests,
+    ReturnNativeTests,
     WeightColumnFitMixinTests,
     WeightColumnInitMixinTests,
 )
@@ -73,6 +74,7 @@ class TestTransform(
     GenericTransformTests,
     GenericImputerTransformTestsWeight,
     GenericImputerTransformTests,
+    ReturnNativeTests,
 ):
     """Tests for transformer.transform."""
 

--- a/tests/imputers/test_MedianImputer.py
+++ b/tests/imputers/test_MedianImputer.py
@@ -9,6 +9,7 @@ from tests.base_tests import (
     GenericFitTests,
     GenericTransformTests,
     OtherBaseBehaviourTests,
+    ReturnNativeTests,
     WeightColumnFitMixinTests,
     WeightColumnInitMixinTests,
 )
@@ -112,6 +113,7 @@ class TestTransform(
     GenericImputerTransformTests,
     GenericImputerTransformTestsWeight,
     GenericTransformTests,
+    ReturnNativeTests,
 ):
     """Tests for transformer.transform."""
 

--- a/tests/imputers/test_ModeImputer.py
+++ b/tests/imputers/test_ModeImputer.py
@@ -8,6 +8,7 @@ from tests.base_tests import (
     GenericFitTests,
     GenericTransformTests,
     OtherBaseBehaviourTests,
+    ReturnNativeTests,
     WeightColumnFitMixinTests,
     WeightColumnInitMixinTests,
 )
@@ -313,6 +314,7 @@ class TestTransform(
     GenericTransformTests,
     GenericImputerTransformTestsWeight,
     GenericImputerTransformTests,
+    ReturnNativeTests,
 ):
     """Tests for transformer.transform."""
 

--- a/tests/imputers/test_NearestMeanResponseImputer.py
+++ b/tests/imputers/test_NearestMeanResponseImputer.py
@@ -7,6 +7,7 @@ from tests.base_tests import (
     ColumnStrListInitTests,
     GenericFitTests,
     GenericTransformTests,
+    ReturnNativeTests,
 )
 from tests.imputers.test_BaseImputer import (
     GenericImputerTransformTests,
@@ -79,6 +80,7 @@ class TestFit(GenericFitTests):
 class TestTransform(
     GenericTransformTests,
     GenericImputerTransformTests,
+    ReturnNativeTests,
 ):
     """Tests for transformer.transform."""
 

--- a/tests/imputers/test_NullIndicator.py
+++ b/tests/imputers/test_NullIndicator.py
@@ -7,6 +7,7 @@ from tests.base_tests import (
     ColumnStrListInitTests,
     GenericTransformTests,
     OtherBaseBehaviourTests,
+    ReturnNativeTests,
 )
 from tubular.imputers import NullIndicator
 
@@ -19,7 +20,7 @@ class TestInit(ColumnStrListInitTests):
         cls.transformer_name = "NullIndicator"
 
 
-class TestTransform(GenericTransformTests):
+class TestTransform(GenericTransformTests, ReturnNativeTests):
     """Tests for NullIndicator.transform()."""
 
     @classmethod

--- a/tests/mapping/test_BaseMappingTransformMixin.py
+++ b/tests/mapping/test_BaseMappingTransformMixin.py
@@ -5,6 +5,7 @@ import narwhals as nw
 import pandas as pd
 import polars as pl
 import pytest
+from beartype.roar import BeartypeCallHintParamViolation
 
 import tests.test_data as d
 from tests.base_tests import (
@@ -266,8 +267,7 @@ class TestTransform(GenericTransformTests):
         x_fitted = transformer.fit(df, df["c"])
 
         with pytest.raises(
-            TypeError,
-            match="BaseMappingTransformMixin: X should be a polars or pandas DataFrame/LazyFrame",
+            BeartypeCallHintParamViolation,
         ):
             x_fitted.transform(X=non_df)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -67,7 +67,7 @@ def _align_pandas_and_polars_dtypes(
     return polars_df
 
 
-def assert_frame_equal_dispatch(df1: FrameT, df2: FrameT) -> None:
+def assert_frame_equal_dispatch(df1: FrameT, df2: FrameT, **pandas_kwargs) -> None:
     """fixture to return correct pandas/polars assert_frame_equal method
 
     Parameters
@@ -78,10 +78,13 @@ def assert_frame_equal_dispatch(df1: FrameT, df2: FrameT) -> None:
     df1 : pd.DataFrame
         second df for comparison
 
+    pandas_kwargs:
+        additional kwargs to pass to pandas assert_frame_equal
+
     """
 
     if isinstance(df1, pd.DataFrame) and isinstance(df2, pd.DataFrame):
-        return assert_pandas_frame_equal(df1, df2)
+        return assert_pandas_frame_equal(df1, df2, **pandas_kwargs)
 
     if isinstance(df1, pl.DataFrame) and isinstance(df2, pl.DataFrame):
         return assert_polars_frame_equal(df1, df2)

--- a/tests/utils/test_narwhalify_X_if_needed.py
+++ b/tests/utils/test_narwhalify_X_if_needed.py
@@ -1,0 +1,49 @@
+import narwhals as nw
+import pytest
+
+from tests.utils import assert_frame_equal_dispatch, dataframe_init_dispatch
+from tubular._utils import _narwhalify_X_if_needed
+
+
+@pytest.mark.parametrize("library", ["pandas", "polars"])
+def test_narwhalification(library):
+    "test pandas and polars dfs narwhalified by function"
+
+    df_dict = {
+        "a": [1, 2, 3],
+        "b": ["a", "b", "c"],
+    }
+
+    df = dataframe_init_dispatch(dataframe_dict=df_dict, library=library)
+
+    output = _narwhalify_X_if_needed(df)
+
+    assert isinstance(
+        output,
+        nw.DataFrame,
+    ), "df has not been converted to narwhals as expected"
+
+    assert_frame_equal_dispatch(output.to_native(), df)
+
+
+@pytest.mark.parametrize("library", ["pandas", "polars"])
+def test_narwhals_frame_left_alone(library):
+    "test pandas and polars dfs narwhalified by function"
+
+    df_dict = {
+        "a": [1, 2, 3],
+        "b": ["a", "b", "c"],
+    }
+
+    df = dataframe_init_dispatch(dataframe_dict=df_dict, library=library)
+
+    df = nw.from_native(df)
+
+    output = _narwhalify_X_if_needed(df)
+
+    assert isinstance(
+        output,
+        nw.DataFrame,
+    ), "df has not been converted to narwhals as expected"
+
+    assert_frame_equal_dispatch(output.to_native(), df.to_native())

--- a/tests/utils/test_narwhalify_y_if_needed.py
+++ b/tests/utils/test_narwhalify_y_if_needed.py
@@ -1,0 +1,65 @@
+import narwhals as nw
+import pytest
+from pandas.testing import assert_series_equal as assert_pandas_series_equal
+from polars.testing import assert_series_equal as assert_polars_series_equal
+
+from tests.utils import dataframe_init_dispatch
+from tubular._utils import _narwhalify_y_if_needed
+
+
+@pytest.mark.parametrize("library", ["pandas", "polars"])
+def test_narwhalification(library):
+    "test pandas and polars series narwhalified by function"
+
+    df_dict = {
+        "a": [1, 2, 3],
+    }
+
+    df = dataframe_init_dispatch(dataframe_dict=df_dict, library=library)
+
+    series = df["a"]
+
+    native_namespace = nw.get_native_namespace(series).__name__
+
+    output = _narwhalify_y_if_needed(series)
+
+    assert isinstance(
+        output,
+        nw.Series,
+    ), "series has not been converted to narwhals as expected"
+
+    if native_namespace == "pandas":
+        assert_pandas_series_equal(output.to_native(), series)
+
+    if native_namespace == "polars":
+        assert_polars_series_equal(output.to_native(), series)
+
+
+@pytest.mark.parametrize("library", ["pandas", "polars"])
+def test_narwhals_series_left_alone(library):
+    "test pandas and polars series narwhalified by function"
+
+    df_dict = {
+        "a": [1, 2, 3],
+    }
+
+    df = dataframe_init_dispatch(dataframe_dict=df_dict, library=library)
+
+    series = df["a"]
+
+    series = nw.from_native(series, allow_series=True)
+
+    output = _narwhalify_y_if_needed(series)
+
+    native_namespace = nw.get_native_namespace(series).__name__
+
+    assert isinstance(
+        output,
+        nw.Series,
+    ), "series has not been converted to narwhals as expected"
+
+    if native_namespace == "pandas":
+        assert_pandas_series_equal(output.to_native(), series.to_native())
+
+    if native_namespace == "polars":
+        assert_polars_series_equal(output.to_native(), series.to_native())

--- a/tubular/_utils.py
+++ b/tubular/_utils.py
@@ -1,9 +1,52 @@
-from typing import Literal
+from typing import Literal, Optional
 
 import narwhals as nw
 import pandas as pd
+from beartype import beartype
 from narwhals.typing import IntoDType
 from numpy.typing import ArrayLike
+
+from tubular.types import DataFrame, Series
+
+
+@beartype
+def _narwhalify_X_if_needed(X: DataFrame) -> nw.DataFrame:
+    """narwhalifies dataframe, if dataframe is not already narwhals
+
+    Parameters
+    ----------
+    X: pd/pl/nw.Series
+        DataFrame to narwhalify if pd/pl type
+
+    Returns
+    ----------
+    nw.DataFrame: narwhalified dataframe
+    """
+
+    if not isinstance(X, nw.DataFrame):
+        X = nw.from_native(X)
+
+    return X
+
+
+@beartype
+def _narwhalify_y_if_needed(y: Optional[Series] = None) -> Optional[nw.Series]:
+    """narwhalifies series, if series is not already narwhals
+
+    Parameters
+    ----------
+    y: pd/pl/nw.Series
+        series to narwhalify if pd/pl type
+
+    Returns
+    ----------
+    nw.Series: narwhalified series
+    """
+
+    if y is not None and not isinstance(y, nw.Series):
+        y = nw.from_native(y, allow_series=True)
+
+    return y
 
 
 def _assess_pandas_object_column(pandas_df: pd.DataFrame, col: str) -> tuple[str, str]:

--- a/tubular/dates.py
+++ b/tubular/dates.py
@@ -439,7 +439,7 @@ class DateDifferenceTransformer(BaseDateTwoColumnTransformer):
         will be used.
     units : str, default = 'D'
         Accepted values are "week", "fortnight", "lunar_month", "common_year", "custom_days", 'D', 'h', 'm', 's'
-    copy : bool, default = True
+    copy : bool, default = False
         Should X be copied prior to transform? Copy argument no longer used and will be deprecated in a future release
     verbose: bool, default = False
         Control level of detail in printouts
@@ -471,7 +471,7 @@ class DateDifferenceTransformer(BaseDateTwoColumnTransformer):
             "m",
             "s",
         ] = "D",
-        copy: bool | None = None,
+        copy: bool = False,
         verbose: bool = False,
         drop_original: bool = False,
         custom_days_divider: int = None,

--- a/tubular/imputers.py
+++ b/tubular/imputers.py
@@ -3,19 +3,20 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Optional, Union
+from typing import Literal, Optional, Union
 
 import narwhals as nw
-import narwhals.selectors as ncs
 import polars as pl
 from beartype import beartype
 
-from tubular._utils import _assess_pandas_object_column
+from tubular._utils import (
+    _assess_pandas_object_column,
+    _narwhalify_X_if_needed,
+    _narwhalify_y_if_needed,
+)
 from tubular.base import BaseTransformer
 from tubular.mixins import WeightColumnMixin
-
-if TYPE_CHECKING:
-    from narwhals.typing import FrameT
+from tubular.types import DataFrame, Series
 
 pl.enable_string_cache()
 
@@ -32,15 +33,40 @@ class BaseImputer(BaseTransformer):
     polars_compatible : bool
         class attribute, indicates whether transformer has been converted to polars/pandas agnostic narwhals framework
 
+    return_native: bool, default = True
+        Controls whether transformer returns narwhals or native pandas/polars type
+
     """
 
     polars_compatible = True
 
     FITS = False
 
-    @nw.narwhalify
-    def transform(self, X: FrameT) -> FrameT:
-        """Impute missing values with median values calculated from fit method.
+    def _generate_imputation_expressions(self, expr: nw.Expr, col: str) -> nw.Expr:
+        """update input expressions to include imputation.
+
+        Parameters
+        ----------
+        expr : nw.Expr
+            initial expression
+        col: str
+            column being imputed
+
+        Returns
+        -------
+        nw.Expr: updated expression, with imputation
+
+        """
+
+        return (
+            expr.fill_null(value=self.impute_values_[col])
+            if (self.impute_values_[col] is not None)
+            else expr
+        )
+
+    @beartype
+    def transform(self, X: DataFrame) -> DataFrame:
+        """Impute missing values with values calculated from fit method.
 
         Parameters
         ----------
@@ -53,20 +79,20 @@ class BaseImputer(BaseTransformer):
             Transformed input X with nulls imputed with the median value for the specified columns.
 
         """
-        self.check_is_fitted(["impute_values_"])
+        self.check_is_fitted("impute_values_")
 
-        X = nw.from_native(super().transform(X))
+        X = _narwhalify_X_if_needed(X)
 
-        new_col_expressions = [
-            nw.col(c).fill_null(self.impute_values_[c])
-            if self.impute_values_[c] is not None
-            else nw.col(c)
-            for c in self.columns
-        ]
+        super().transform(X)
 
-        return X.with_columns(
-            new_col_expressions,
-        )
+        transform_expressions = {
+            col: self._generate_imputation_expressions(nw.col(col), col)
+            for col in self.columns
+        }
+
+        X = X.with_columns(**transform_expressions)
+
+        return X if not self.return_native else X.to_native()
 
 
 class ArbitraryImputer(BaseImputer):
@@ -89,6 +115,9 @@ class ArbitraryImputer(BaseImputer):
 
     polars_compatible : bool
         class attribute, indicates whether transformer has been converted to polars/pandas agnostic narwhals framework
+
+    return_native: bool, default = True
+        Controls whether transformer returns narwhals or native pandas/polars type
     """
 
     polars_compatible = True
@@ -109,9 +138,30 @@ class ArbitraryImputer(BaseImputer):
         for c in self.columns:
             self.impute_values_[c] = self.impute_value
 
+    def cat_to_enum_expr(self, expr: nw.Expr, categories: list[str]) -> nw.Expr:
+        """update expression to include handling of category types to allow new
+        impute value category
+
+        Parameters
+        ----------
+        expr : nw.Expr
+            initial expression
+        categories: list[str]
+            list of categories in field initially
+
+        Returns
+        -------
+        nw.Expr: updated expression, with category type handling
+
+        """
+
+        return expr.cast(nw.Enum(set(categories + [self.impute_value])))
+
     def _check_impute_value_type_works_with_columns(
         self,
-        X: FrameT,
+        X: DataFrame,
+        schema: nw.Schema,
+        native_namespace: Literal["pandas", "polars"],
     ) -> tuple[dict[str, str], list[StopIteration]]:
         """raises TypeError if there is a type clash between impute_value and columns in X for imputation
 
@@ -129,22 +179,44 @@ class ArbitraryImputer(BaseImputer):
             list of Unknown type columns, singled out for different type handling
 
         """
-        object_columns = set(self.columns).intersection(
-            [col for col, dtype in X.schema.items() if dtype == nw.Object],
-        )
-        cat_columns = set(self.columns).intersection(
-            X.select(ncs.categorical()).columns,
-        )
-        num_columns = set(self.columns).intersection(X.select(ncs.numeric()).columns)
-        bool_columns = set(self.columns).intersection(X.select(ncs.boolean()).columns)
-        str_columns = set(self.columns).intersection(X.select(ncs.string()).columns)
-        null_columns = set(self.columns).intersection(
-            [col for col, dtype in X.schema.items() if (dtype == nw.Unknown)],
-        )
+
+        object_columns = set()
+        cat_columns = set()
+        num_columns = set()
+        bool_columns = set()
+        str_columns = set()
+        null_columns = set()
+        for col in self.columns:
+            dtype = schema[col]
+            if dtype == nw.Object:
+                object_columns.add(col)
+            elif dtype == nw.Categorical:
+                cat_columns.add(col)
+            elif dtype in [
+                nw.Float32,
+                nw.Float64,
+                nw.Int64,
+                nw.Int32,
+                nw.Int16,
+                nw.Int8,
+            ]:
+                num_columns.add(col)
+            elif dtype == nw.Boolean:
+                bool_columns.add(col)
+            elif dtype == nw.String:
+                str_columns.add(col)
+            elif dtype == nw.Unknown:
+                null_columns.add(col)
+
+        if len(cat_columns) > 0 and native_namespace == "pandas":
+            warnings.warn(
+                f"{self.classname()}: this transformer will convert unordered categorical columns to ordered for pandas dfs",
+                stacklevel=2,
+            )
 
         # start with object columns, which can be a massive nuisance from pandas
         pandas_object_cols_to_polars_types = {}
-        if len(object_columns) > 0 and nw.get_native_namespace(X).__name__ == "pandas":
+        if len(object_columns) > 0 and native_namespace == "pandas":
             # pull out boolean columns from generic object columns
             for col in object_columns:
                 _, polars_type = _assess_pandas_object_column(
@@ -206,9 +278,12 @@ class ArbitraryImputer(BaseImputer):
             .union(null_columns),
         )
         if len(bad_type_cols) != 0:
+            bad_types = {
+                name: dtype for name, dtype in schema.items() if name in bad_type_cols
+            }
             msg = f"""
                 {self.classname()}: transformer can only handle Float/Int/Boolean/String/Categorical/Unknown type columns
-                but got columns with types {X.select(list(bad_type_cols)).schema}
+                but got columns with types {bad_types}
                 """
             raise TypeError(
                 msg,
@@ -216,8 +291,8 @@ class ArbitraryImputer(BaseImputer):
 
         return pandas_object_cols_to_polars_types, null_columns
 
-    @nw.narwhalify
-    def transform(self, X: FrameT) -> FrameT:
+    @beartype
+    def transform(self, X: DataFrame) -> DataFrame:
         """Impute missing values with the supplied impute_value.
         If columns is None all columns in X will be imputed.
 
@@ -232,17 +307,21 @@ class ArbitraryImputer(BaseImputer):
             Transformed input X with nulls imputed with the specified impute_value, for the specified columns.
         """
 
-        self.check_is_fitted(["impute_value"])
-        self.columns_check(X)
+        X = _narwhalify_X_if_needed(X)
 
-        if len(X) == 0:
-            msg = f"{self.classname()}: X has no rows; {X.shape}"
-            raise ValueError(msg)
+        schema = X.schema
+        native_namespace = nw.get_native_namespace(X).__name__
+
+        BaseTransformer.transform(self, X)
 
         (
             pandas_object_cols_to_polars_types,
             null_columns,
-        ) = self._check_impute_value_type_works_with_columns(X)
+        ) = self._check_impute_value_type_works_with_columns(
+            X,
+            schema,
+            native_namespace,
+        )
 
         # Save the original dtypes BEFORE we cast anything
         original_dtypes = {}
@@ -251,32 +330,43 @@ class ArbitraryImputer(BaseImputer):
                 # overwrite type if necessary, e.g. object->boolean
                 pandas_object_cols_to_polars_types[col]
                 if col in pandas_object_cols_to_polars_types
-                else X[col].dtype
+                else schema[col]
             )
 
-        # first handle categorical vars
-        # need to explicitly add category for pandas
-        is_pandas = nw.get_native_namespace(X).__name__ == "pandas"
-        if is_pandas:
-            X = nw.to_native(X)
-            for col in self.columns:
-                if str(original_dtypes[col]) == "Categorical" and (
-                    self.impute_value not in X[col].cat.categories
-                ):
-                    X[col] = X[col].cat.add_categories(
-                        self.impute_value,
-                    )
-            X = nw.from_native(X)
+        # have to handle categorical vars for pandas upfront
+        if native_namespace == "pandas":
+            transform_expressions = {
+                col: self.cat_to_enum_expr(
+                    nw.col(col),
+                    categories=X.get_column(col).cat.get_categories().to_list(),
+                )
+                if ((schema[col] == nw.Categorical) or (schema[col] == nw.Enum))
+                else nw.col(col)
+                for col in self.columns
+            }
+        else:
+            transform_expressions = {col: nw.col(col) for col in self.columns}
 
-        X = nw.from_native(super().transform(X))
+        # next handle imputing
+        transform_expressions = {
+            col: self._generate_imputation_expressions(
+                transform_expressions[col],
+                col,
+            )
+            for col in self.columns
+        }
 
-        # restore types that may have changed from e.g. fully imputing a float
-        # column may convert to int
-        # skip for Unknown type columns, which will warn and then convert to impute_value type
-        for col in set(self.columns).difference(null_columns):
-            X = X.with_columns(nw.col(col).cast(original_dtypes[col]))
+        # finally manage types
+        transform_expressions = {
+            col: transform_expressions[col].cast(original_dtypes[col])
+            if (col not in null_columns)
+            else transform_expressions[col]
+            for col in self.columns
+        }
 
-        return X
+        X = X.with_columns(**transform_expressions)
+
+        return X if not self.return_native else X.to_native()
 
 
 class MedianImputer(BaseImputer, WeightColumnMixin):
@@ -303,6 +393,9 @@ class MedianImputer(BaseImputer, WeightColumnMixin):
     polars_compatible : bool
         class attribute, indicates whether transformer has been converted to polars/pandas agnostic narwhals framework
 
+    return_native: bool, default = True
+        Controls whether transformer returns narwhals or native pandas/polars type
+
     """
 
     polars_compatible = True
@@ -319,8 +412,8 @@ class MedianImputer(BaseImputer, WeightColumnMixin):
 
         WeightColumnMixin.check_and_set_weight(self, weights_column)
 
-    @nw.narwhalify
-    def fit(self, X: FrameT, y: nw.Series | None = None) -> FrameT:
+    @beartype
+    def fit(self, X: DataFrame, y: Optional[Series] = None) -> MedianImputer:
         """Calculate median values to impute with from X.
 
         Parameters
@@ -332,6 +425,10 @@ class MedianImputer(BaseImputer, WeightColumnMixin):
             Not required.
 
         """
+
+        X = _narwhalify_X_if_needed(X)
+        y = _narwhalify_y_if_needed(y)
+
         super().fit(X, y)
 
         self.impute_values_ = {}
@@ -393,6 +490,9 @@ class MeanImputer(WeightColumnMixin, BaseImputer):
     polars_compatible : bool
         class attribute, indicates whether transformer has been converted to polars/pandas agnostic narwhals framework
 
+    return_native: bool, default = True
+        Controls whether transformer returns narwhals or native pandas/polars type
+
     """
 
     polars_compatible = True
@@ -409,8 +509,8 @@ class MeanImputer(WeightColumnMixin, BaseImputer):
 
         WeightColumnMixin.check_and_set_weight(self, weights_column)
 
-    @nw.narwhalify
-    def fit(self, X: FrameT, y: nw.Series | None = None) -> MeanImputer:
+    @beartype
+    def fit(self, X: DataFrame, y: Optional[Series] = None) -> MeanImputer:
         """Calculate mean values to impute with from X.
 
         Parameters
@@ -422,6 +522,10 @@ class MeanImputer(WeightColumnMixin, BaseImputer):
             Not required.
 
         """
+
+        X = _narwhalify_X_if_needed(X)
+        y = _narwhalify_y_if_needed(y)
+
         super().fit(X, y)
 
         self.impute_values_ = {}
@@ -478,6 +582,9 @@ class ModeImputer(BaseImputer, WeightColumnMixin):
     polars_compatible : bool
         class attribute, indicates whether transformer has been converted to polars/pandas agnostic narwhals framework
 
+    return_native: bool, default = True
+        Controls whether transformer returns narwhals or native pandas/polars type
+
     """
 
     polars_compatible = True
@@ -494,8 +601,8 @@ class ModeImputer(BaseImputer, WeightColumnMixin):
 
         WeightColumnMixin.check_and_set_weight(self, weights_column)
 
-    @nw.narwhalify
-    def fit(self, X: FrameT, y: nw.Series | None = None) -> FrameT:
+    @beartype
+    def fit(self, X: DataFrame, y: Optional[Series] = None) -> ModeImputer:
         """Calculate mode values to impute with from X - in the event of a tie,
         the highest modal value will be returned.
 
@@ -508,6 +615,10 @@ class ModeImputer(BaseImputer, WeightColumnMixin):
             Not required.
 
         """
+
+        X = _narwhalify_X_if_needed(X)
+        y = _narwhalify_y_if_needed(y)
+
         super().fit(X, y)
 
         self.impute_values_ = {}
@@ -580,6 +691,9 @@ class NearestMeanResponseImputer(BaseImputer):
     polars_compatible : bool
         class attribute, indicates whether transformer has been converted to polars/pandas agnostic narwhals framework
 
+    return_native: bool, default = True
+        Controls whether transformer returns narwhals or native pandas/polars type
+
     """
 
     polars_compatible = True
@@ -593,8 +707,8 @@ class NearestMeanResponseImputer(BaseImputer):
     ) -> None:
         super().__init__(columns=columns, **kwargs)
 
-    @nw.narwhalify
-    def fit(self, X: FrameT, y: nw.Series) -> FrameT:
+    @beartype
+    def fit(self, X: DataFrame, y: Series) -> NearestMeanResponseImputer:
         """Calculate mean values to impute with.
 
         Parameters
@@ -608,6 +722,9 @@ class NearestMeanResponseImputer(BaseImputer):
             to the average response of the unknown levels is selected as the imputation value.
 
         """
+
+        X = _narwhalify_X_if_needed(X)
+        y = _narwhalify_y_if_needed(y)
 
         super().fit(X, y)
 
@@ -667,6 +784,9 @@ class NullIndicator(BaseTransformer):
     polars_compatible : bool
         class attribute, indicates whether transformer has been converted to polars/pandas agnostic narwhals framework
 
+    return_native: bool, default = True
+        Controls whether transformer returns narwhals or native pandas/polars type
+
     """
 
     polars_compatible = True
@@ -678,8 +798,8 @@ class NullIndicator(BaseTransformer):
     ) -> None:
         super().__init__(columns=columns, **kwargs)
 
-    @nw.narwhalify
-    def transform(self, X: FrameT) -> FrameT:
+    @beartype
+    def transform(self, X: DataFrame) -> DataFrame:
         """Create new columns indicating the position of null values for each variable in self.columns.
 
         Parameters
@@ -688,11 +808,13 @@ class NullIndicator(BaseTransformer):
             Data to add indicators to.
 
         """
-        X = nw.from_native(super().transform(X))
+        super().transform(X)
+
+        X = _narwhalify_X_if_needed(X)
 
         for c in self.columns:
             X = X.with_columns(
-                (nw.col(c).is_null()).cast(nw.Boolean).alias(f"{c}_nulls"),
+                (nw.col(c).is_null()).alias(f"{c}_nulls"),
             )
 
-        return X
+        return X if not self.return_native else X.to_native()

--- a/tubular/mapping.py
+++ b/tubular/mapping.py
@@ -14,6 +14,7 @@ from beartype import beartype
 
 from tubular._utils import new_narwhals_series_with_optimal_pandas_types
 from tubular.base import BaseTransformer
+from tubular.types import DataFrame
 
 if TYPE_CHECKING:
     from narwhals.typing import FrameT
@@ -148,8 +149,9 @@ class BaseMappingTransformMixin(BaseTransformer):
 
     polars_compatible = True
 
+    @beartype
     @nw.narwhalify
-    def transform(self, X: FrameT) -> FrameT:
+    def transform(self, X: DataFrame) -> DataFrame:
         """Applies the mapping defined in the mappings dict to each column in the columns
         attribute.
 

--- a/tubular/misc.py
+++ b/tubular/misc.py
@@ -41,7 +41,7 @@ class SetValueTransformer(BaseTransformer):
         self,
         columns: str | list[str],
         value: type,
-        copy: bool | None = None,
+        copy: bool = False,
         **kwargs: dict[str, bool],
     ) -> None:
         self.value = value

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -1304,7 +1304,7 @@ class OneHotEncodingTransformer(
     drop_original : bool, default = False
         Should original columns be dropped after creating dummy fields?
 
-    copy : bool, default = True
+    copy : bool, default = False
         Should X be copied prior to transform? Should X be copied prior to transform? Copy argument no longer used and will be deprecated in a future release
 
     verbose : bool, default = True
@@ -1336,7 +1336,7 @@ class OneHotEncodingTransformer(
         wanted_values: dict[str, list[str]] | None = None,
         separator: str = "_",
         drop_original: bool = False,
-        copy: bool | None = None,
+        copy: bool = False,
         verbose: bool = False,
         **kwargs: dict[str, bool],
     ) -> None:

--- a/tubular/strings.py
+++ b/tubular/strings.py
@@ -61,7 +61,7 @@ class SeriesStrMethodTransformer(NewColumnNameMixin, BaseTransformer):
         new_column_name: str,
         pd_method_name: str,
         columns: list,
-        copy: bool | None = None,
+        copy: bool = False,
         pd_method_kwargs: dict[str, object] | None = None,
         **kwargs: dict[str, bool],
     ) -> None:

--- a/tubular/types.py
+++ b/tubular/types.py
@@ -1,0 +1,19 @@
+from typing import Union
+
+import narwhals as nw
+import pandas as pd
+import polars as pl
+
+DataFrame = Union[
+    pd.DataFrame,
+    pl.DataFrame,
+    pl.LazyFrame,
+    nw.DataFrame,
+    nw.LazyFrame,
+]
+
+Series = Union[
+    pd.Series,
+    pl.Series,
+    nw.Series,
+]


### PR DESCRIPTION
PR addressing live performance issues, key issues were:

- layered narwhalify calls becoming impactful in live setting
- lots of use of methods which instantiate objects or copies, e.g. with_columns, select, schema
- copies being create in BaseTranformer
- moved fit/transform type checking to beartype