### PR TITLE
import narwhals DType to enable compatibility with narwhals 2.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,12 +24,15 @@ Changed
 - bugfix: updated env to make package importable, added basic test for this
 - feat: added BaseAggregationTransformer and AggregateRowOverColumnsTransformer classes in new aggregations module
 - narwhalified DatetimeSinusoidCalculator '#425 <https://github.com/azukds/tubular/issues/425>_' 
-- Added deprecated warning for DateDiffLeapYearTransformer `#244 <https://github.com/azukds/tubular/issues/244>`
+- Added deprecated warning for DateDiffLeapYearTransformer `#244 <https://github.com/azukds/tubular/issues/244>_`
 - Added new units 'week', 'fornight', 'lunar_month', 'common_year' and 'custom_days' to DateDifferenceTransformer. The time component will be truncated for these units and for unit 'D'.
-- feat: optimisation changes to BaseTransfomer and imputers file. Edited to reduce number of copies and type changes from to/from_native calls, and select/with_columns being called many times.
+- feat: optimisation changes to BaseTransfomer and imputers file. Edited to reduce number of copies and type changes from to/from_native calls, and select/with_columns being called many times. `#444 <https://github.com/azukds/tubular/issues/444>_`
 - feat: added 'return_native' argument to BaseTransfomer to control whether native or narwhals types are returned, and limit type changes. Idea is for this to be rolled out across transformers.
 - feat: made creation of copies in BaseTransfomer optional, and default to False.
-- feat: optimisation changes to BaseNominalTransformer, reduced select being called many times, added 'return_native_override' argument.
+- feat: optimisation changes to BaseNominalTransformer, reduced select being called many times, added 'return_native_override' argument. `#450 <https://github.com/azukds/tubular/issues/450>_``
+- chore: turned off beartype for private GroupRareLevelsTransformer method in order to uncap narwhals `#455 <https://github.com/azukds/tubular/issues/455>`
+- feat: optimisation changes for GroupRareLevelsTransformer `#446 <https://github.com/azukds/tubular/issues/446>_`
+- placeholder
 - placeholder
 
 1.4.4 (24/06/2025)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 dependencies = [
     "pandas>=1.5.0",
     "scikit-learn>=1.2.0",
-    "narwhals < 2.0.0",
+    "narwhals >= 1.31.0",
     "polars < 1.32.0",
     "beartype >= 0.19.0",
     "typing-extensions>=4.5.0",

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Literal, Optional, Union
 import narwhals as nw
 import numpy as np
 from beartype import beartype
+from narwhals.dtypes import DType  # noqa: F401
 
 from tubular._utils import (
     _convert_dataframe_to_narwhals,
@@ -353,6 +354,7 @@ class GroupRareLevelsTransformer(BaseTransformer, WeightColumnMixin):
 
         self.unseen_levels_to_rare = unseen_levels_to_rare
 
+    @beartype
     def _check_str_like_columns(self, schema: nw.Schema) -> None:
         """check that transformer being called on only str-like columns
 

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -353,14 +353,13 @@ class GroupRareLevelsTransformer(BaseTransformer, WeightColumnMixin):
 
         self.unseen_levels_to_rare = unseen_levels_to_rare
 
-    @beartype
-    def _check_str_like_columns(self, X: DataFrame, schema: nw.Schema) -> None:
+    def _check_str_like_columns(self, schema: nw.Schema) -> None:
         """check that transformer being called on only str-like columns
 
         Parameters
         ----------
-        X : pd/pl.DataFrame
-            Data to transform
+        schema: nw.Schema
+            schema of input data
 
         """
 
@@ -451,7 +450,7 @@ class GroupRareLevelsTransformer(BaseTransformer, WeightColumnMixin):
 
         schema = X.schema
 
-        self._check_str_like_columns(X, schema)
+        self._check_str_like_columns(schema)
 
         self._check_for_nulls(X)
 
@@ -536,7 +535,7 @@ class GroupRareLevelsTransformer(BaseTransformer, WeightColumnMixin):
 
         schema = X.schema
 
-        self._check_str_like_columns(X, schema)
+        self._check_str_like_columns(schema)
 
         self._check_for_nulls(X)
 


### PR DESCRIPTION
build pipeline was failing for later narwhals versions due to beartype not liking nw.Schema. import narwhals DType to fix this and uncapped narwhals in toml

https://github.com/azukds/tubular/issues/455