### PR TITLE
fix: Use 'bitwise or' instead of 'or' for boolean expr

### DIFF
--- a/tubular/dates.py
+++ b/tubular/dates.py
@@ -440,7 +440,7 @@ class DateDiffLeapYearTransformer(BaseDateTwoColumnTransformer):
             X = X.with_columns(
                 nw.when(
                     (nw.col(self.columns[0]).is_null())
-                    or (nw.col(self.columns[1]).is_null()),
+                    | (nw.col(self.columns[1]).is_null()),
                 )
                 .then(
                     self.missing_replacement,


### PR DESCRIPTION
# Description

As per title, this PR replaces the `or` with the "bitwise or" (`|`) operator for evaluate expressions.

It was spotted in https://github.com/narwhals-dev/narwhals/pull/2985, which once merged won't allow to use `or` for expressions and series (aligning the behavior with pandas, Polars and numpy)