### PR TITLE
Optimize DatetimeSinusoidCalculator

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,7 +37,7 @@ Changed
 - feat: optimisation changes to BaseNominalTransformer, reduced select being called many times, added 'return_native_override' argument.
 - feat: optimisation changes to WeightColumnMixin, combined all weight checks into a single .select call and used narhwals is_nan
 - feat: optimisation chnages to BaseCappingTransformer, added 'return_native_override' argument to BaseCappingTransformer and BaseNumericTransformer.
-- feat: optimisation chnages to DatetimeSinusoidCalculator, added 'return_native_override' argument to DatetimeSinusoidCalculator, reduced with_columns being called many times. https://github.com/azukds/tubular/issues/465
+
 1.4.4 (24/06/2025)
 ------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,7 @@ Changed
 ^^^^^^^
 
 - feat: optimisations for MappingTransformer and BaseMappingTransformerMixin
+- feat: optimisation chnages to DatetimeSinusoidCalculator, added 'return_native_override' argument to DatetimeSinusoidCalculator, reduced with_columns being called many times. https://github.com/azukds/tubular/issues/465
 
 1.4.5 (19/08/2025)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,7 +37,7 @@ Changed
 - feat: optimisation changes to BaseNominalTransformer, reduced select being called many times, added 'return_native_override' argument.
 - feat: optimisation changes to WeightColumnMixin, combined all weight checks into a single .select call and used narhwals is_nan
 - feat: optimisation chnages to BaseCappingTransformer, added 'return_native_override' argument to BaseCappingTransformer and BaseNumericTransformer.
-
+- feat: optimisation chnages to DatetimeSinusoidCalculator, added 'return_native_override' argument to DatetimeSinusoidCalculator, reduced with_columns being called many times. https://github.com/azukds/tubular/issues/465
 1.4.4 (24/06/2025)
 ------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,7 @@ Changed
 ^^^^^^^
 
 - feat: optimisations for MeanResponseTransformer, further optimisations for  MappingTransformer `#451 <https://github.com/azukds/tubular/issues/451>_`
-- placeholder
+- feat: optimisation chnages to DatetimeSinusoidCalculator, added 'return_native_override' argument to DatetimeSinusoidCalculator, reduced with_columns being called many times. https://github.com/azukds/tubular/issues/465
 - placeholder
 
 1.4.6 (19/08/2025)
@@ -33,7 +33,7 @@ Changed
 ^^^^^^^
 
 - feat: optimisations for MappingTransformer and BaseMappingTransformerMixin
-- feat: optimisation chnages to DatetimeSinusoidCalculator, added 'return_native_override' argument to DatetimeSinusoidCalculator, reduced with_columns being called many times. https://github.com/azukds/tubular/issues/465
+
 
 1.4.5 (19/08/2025)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,7 +34,6 @@ Changed
 
 - feat: optimisations for MappingTransformer and BaseMappingTransformerMixin
 
-
 1.4.5 (19/08/2025)
 ------------------
 


### PR DESCRIPTION
Optimised DatetimeSinuosoidCalculator by making use of return_native_override=False argument when calling base/mixin classes, using beartype and building col:expression inside the for loop, and just call with_columns once at the end.
Why?
improve live scoring time
https://github.com/azukds/tubular/issues/465