### PR TITLE
Feature/opt one hot encoder

### DIFF
--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -1364,6 +1364,7 @@ class OneHotEncodingTransformer(
 
     FITS = True
 
+    @beartype
     def __init__(
         self,
         columns: str | list[str] | None = None,
@@ -1381,28 +1382,6 @@ class OneHotEncodingTransformer(
             copy=copy,
             **kwargs,
         )
-
-        if wanted_values is not None:
-            if not isinstance(wanted_values, dict):
-                msg = f"{self.classname()}: wanted_values should be a dictionary"
-                raise TypeError(msg)
-
-            for key, val_list in wanted_values.items():
-                # check key is a string
-                if not isinstance(key, str):
-                    msg = f"{self.classname()}:  Key in 'wanted_values' should be a string"
-                    raise TypeError(msg)
-
-                # check value is a list
-                if not isinstance(val_list, list):
-                    msg = f"{self.classname()}: Values in the 'wanted_values' dictionary should be a list"
-                    raise TypeError(msg)
-
-                # check if each value within the list is a string
-                for val in val_list:
-                    if not isinstance(val, str):
-                        msg = f"{self.classname()}: Entries in 'wanted_values' list should be a string"
-                        raise TypeError(msg)
 
         self.wanted_values = wanted_values
         self.set_drop_original_column(drop_original)

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -1424,7 +1424,7 @@ class OneHotEncodingTransformer(
         """
         X = _convert_dataframe_to_narwhals(X)
         y = _convert_series_to_narwhals(y)
-        
+
         BaseTransformer.fit(self, X=X, y=y)
 
         # Check for nulls
@@ -1510,7 +1510,7 @@ class OneHotEncodingTransformer(
             warnings.warn(warning_msg, UserWarning, stacklevel=2)
 
         return missing_levels
-    
+
     @beartype
     def _get_feature_names(
         self,
@@ -1530,7 +1530,11 @@ class OneHotEncodingTransformer(
         ]
 
     @beartype
-    def transform(self, X: DataFrame, return_native_override: Optional[bool] = None,) -> DataFrame:
+    def transform(
+        self,
+        X: DataFrame,
+        return_native_override: Optional[bool] = None,
+    ) -> DataFrame:
         """Create new dummy columns from categorical fields.
 
         Parameters
@@ -1557,7 +1561,6 @@ class OneHotEncodingTransformer(
 
         X = _convert_dataframe_to_narwhals(X)
         X = BaseTransformer.transform(self, X, return_native_override=False)
-
 
         missing_levels = {}
         for c in self.columns:

--- a/tubular/types.py
+++ b/tubular/types.py
@@ -1,8 +1,9 @@
-from typing import Union
+from typing import Annotated, Union
 
 import narwhals as nw
 import pandas as pd
 import polars as pl
+from beartype.vale import Is
 
 DataFrame = Union[
     pd.DataFrame,
@@ -30,4 +31,11 @@ NumericTypes = [
     nw.UInt32,
     nw.UInt64,
     nw.UInt128,
+]
+
+# needed as by default beartype will just randomly sample to type check elements
+# and we want consistency
+ListOfStrs = Annotated[
+    list,
+    Is[lambda list_arg: all(isinstance(l_value, str) for l_value in list_arg)],
 ]


### PR DESCRIPTION
Optimize one hot encoder transformer by:

Moving away from using narwhalify decorator
Removing to/from native calls withing the code and making use of return_native_override=False argument when calling base classes
Building out the expressions before using functions such as with_columns
The ticket can be found: https://github.com/azukds/tubular/issues/466