### PR TITLE
453 uncap polars version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "pandas>=1.5.0",
     "scikit-learn>=1.2.0",
     "narwhals >= 1.31.0",
-    "polars >= 1.33.0",
+    "polars >= 1.9.0",
     "beartype >= 0.19.0",
     "typing-extensions>=4.5.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "pandas>=1.5.0",
     "scikit-learn>=1.2.0",
     "narwhals >= 1.31.0",
-    "polars < 1.32.0",
+    "polars >= 1.33.0",
     "beartype >= 0.19.0",
     "typing-extensions>=4.5.0",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,21 +4,21 @@ beartype==0.21.0
     # via tubular (pyproject.toml)
 cfgv==3.4.0
     # via pre-commit
-coverage==7.9.1
+coverage==7.10.7
     # via pytest-cov
-distlib==0.3.9
+distlib==0.4.0
     # via virtualenv
 exceptiongroup==1.3.0
     # via pytest
-filelock==3.18.0
+filelock==3.19.1
     # via virtualenv
-identify==2.6.12
+identify==2.6.14
     # via pre-commit
 iniconfig==2.1.0
     # via pytest
-joblib==1.5.1
+joblib==1.5.2
     # via scikit-learn
-narwhals==1.44.0
+narwhals==2.5.0
     # via tubular (pyproject.toml)
 nodeenv==1.9.1
     # via pre-commit
@@ -29,21 +29,21 @@ numpy==2.0.2
     #   scipy
 packaging==25.0
     # via pytest
-pandas==2.3.0
+pandas==2.3.2
     # via tubular (pyproject.toml)
-platformdirs==4.3.8
+platformdirs==4.4.0
     # via virtualenv
 pluggy==1.6.0
     # via pytest
-polars==1.31.0
+polars==1.33.1
     # via tubular (pyproject.toml)
-pre-commit==4.2.0
+pre-commit==4.3.0
     # via tubular (pyproject.toml)
-pyarrow==20.0.0
+pyarrow==21.0.0
     # via tubular (pyproject.toml)
 pygments==2.19.2
     # via pytest
-pytest==8.4.1
+pytest==8.4.2
     # via
     #   tubular (pyproject.toml)
     #   pytest-cov
@@ -51,7 +51,7 @@ pytest==8.4.1
     #   test-aide
 pytest-cov==2.10.1
     # via tubular (pyproject.toml)
-pytest-mock==3.14.1
+pytest-mock==3.15.1
     # via
     #   tubular (pyproject.toml)
     #   test-aide
@@ -75,11 +75,12 @@ threadpoolctl==3.6.0
     # via scikit-learn
 tomli==2.2.1
     # via pytest
-typing-extensions==4.14.0
+typing-extensions==4.15.0
     # via
     #   tubular (pyproject.toml)
     #   exceptiongroup
+    #   virtualenv
 tzdata==2025.2
     # via pandas
-virtualenv==20.31.2
+virtualenv==20.34.0
     # via pre-commit

--- a/tests/imputers/test_ArbitraryImputer.py
+++ b/tests/imputers/test_ArbitraryImputer.py
@@ -158,12 +158,14 @@ class TestTransform(
             expected_dtype = nw.Enum
 
         actual_dtype = df_transformed_nw[column].dtype
+
         assert (
             actual_dtype == expected_dtype
         ), f"{self.transformer_name}: dtype changed unexpectedly in transform, expected {expected_dtype} but got {actual_dtype}"
 
         # also check full df against expectation
         expected = df_nw.clone()
+
         expected = expected.with_columns(
             nw.new_series(name=column, values=expected_values, backend=library).cast(
                 getattr(nw, col_type),

--- a/tests/nominal/test_GroupRareLevelsTransformer.py
+++ b/tests/nominal/test_GroupRareLevelsTransformer.py
@@ -193,9 +193,16 @@ class TestTransform(GenericNominalTransformTests):
 
         df = dataframe_init_dispatch(dataframe_dict=df_dict, library=library)
 
-        df = nw.from_native(df)
+        # set categories for enum
+        categories = ["e", "c", "a", "rare"]
 
-        return df.with_columns(nw.col("c").cast(nw.Categorical)).to_native()
+        return (
+            nw.from_native(df)
+            .with_columns(
+                nw.col("c").cast(nw.Enum(categories=categories)),
+            )
+            .to_native()
+        )
 
     def expected_df_2(self, library="pandas"):
         """Expected output for test_expected_output_weight."""
@@ -247,7 +254,6 @@ class TestTransform(GenericNominalTransformTests):
     @pytest.mark.parametrize("library", ["pandas", "polars"])
     def test_expected_output_no_weight(self, library):
         """Test that the output is expected from transform."""
-
         df = d.create_df_5(library=library)
 
         # first handle nulls
@@ -266,7 +272,7 @@ class TestTransform(GenericNominalTransformTests):
 
         df_transformed = x.transform(df)
 
-        assert_frame_equal_dispatch(df_transformed, expected)
+        assert_frame_equal_dispatch(df_transformed, expected, check_categorical=False)
 
     @pytest.mark.parametrize("library", ["pandas", "polars"])
     def test_expected_output_weight(self, library):
@@ -371,7 +377,9 @@ class TestTransform(GenericNominalTransformTests):
 
         output_df = x.transform(df)
 
-        output_categories = output_df[column].unique()
+        output_categories = (
+            nw.from_native(output_df)[column].cat.get_categories().to_list()
+        )
 
         for cat in expected_removed_cats:
             assert (

--- a/tests/nominal/test_GroupRareLevelsTransformer.py
+++ b/tests/nominal/test_GroupRareLevelsTransformer.py
@@ -371,9 +371,7 @@ class TestTransform(GenericNominalTransformTests):
 
         output_df = x.transform(df)
 
-        output_categories = (
-            nw.from_native(output_df)[column].cat.get_categories().to_list()
-        )
+        output_categories = output_df[column].unique()
 
         for cat in expected_removed_cats:
             assert (

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -596,7 +596,9 @@ class GroupRareLevelsTransformer(BaseTransformer, WeightColumnMixin):
         }
 
         transform_expressions = {
-            c: transform_expressions[c].cast(schema[c])
+            c: transform_expressions[c].cast(
+                nw.Enum(self.non_rare_levels[c] + [self.rare_level_name]),
+            )
             if (schema[c] in [nw.Categorical, nw.Enum])
             else transform_expressions[c]
             for c in self.columns


### PR DESCRIPTION
upgraded polars version to latest 1.33.0, which caused one test to fail - group rare levels transformer.

Investigations showed that the intended behaviour of the transformer was unaffected however, the levels still appeared when calling  nw.from_native(output_df)[column].cat.get_categories().to_list().

The cause of the issue seems to be how new polars deals with categorical data. Polars implements a category mapping for a series of that datatype which is not overwritten, after removal of categories. 

The Solution was to convert the categorical col into Enum which solved the issue, but required some adjustments to other tests