### PR TITLE
updated changelog for major release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,22 +1,33 @@
 Changelog
 =========
 
+Notes on Versioning Approach
+---------------------------
+
 This changelog follows the great advice from https://keepachangelog.com/.
 
 Each section will have a title of the format ``X.Y.Z (YYYY-MM-DD)`` giving the version of the package and the date of release of that version. Unreleased changes i.e. those that have been merged into `main` (e.g. with a .dev suffix) but which are not yet in a new release (on pypi) are added to the changelog but with the title ``X.Y.Z (unreleased)``. Unreleased sections can be combined when they are released and the date of release added to the title.
 
-Subsections for each version can be one of the following;
+Prior to version 2.*, tubular versioning practices were not consistent. Going forwards, we would like developers to stick to semantic versioning rules, described below.
 
-- ``Added`` for new features.
-- ``Changed`` for changes in existing functionality.
-- ``Deprecated`` for soon-to-be removed features.
-- ``Removed`` for now removed features.
-- ``Fixed`` for any bug fixes.
-- ``Security`` in case of vulnerabilities.
+Semantic versioning follows a pattern of MAJOR.MINOR.PATCH where each part represents a specific type of change:
+
+- MAJOR: Incremented for incompatible API changes.
+
+- MINOR: Incremented for added functionality in a backward-compatible manner.
+
+- PATCH: Incremented for backward-compatible bug fixes.
+
+This structure allows developers and users to understand the potential impact of updating to a new version at a glance.
+
+We use the tags:
+- feat: new or improved functionality
+- bug: fix to existing functionality
+- chore: minor improvements to repo health
 
 Each individual change should have a link to the pull request after the description of the change.
 
-1.4.9 (unreleased)
+2.0.0 (16/10/2025)
 ------------------
 
 - chore: refactored unit weight handling into method of WeightColumnMixin, tightened up handling
@@ -44,7 +55,6 @@ Each individual change should have a link to the pull request after the descript
 - chore: doctests for dates module `#502 <https://github.com/azukds/tubular/issues/502>_`
 - chore: doctests for nominal module `#506 <https://github.com/azukds/tubular/issues/506>_`
 - chore: doctests for imputers module `#503 <https://github.com/azukds/tubular/issues/503>_`
-
 
 
 1.4.8 (03/09/25)


### PR DESCRIPTION
We've now started adding to/from json functionality, so it is as good a time as any to improve our versioning approach - this is because jsonified transformers should be restorable across minor version changes, but cannot be guaranteed across major (API breaking) changes.

https://github.com/azukds/tubular/issues/526