### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,6 +2,9 @@
 
 name: Python package build and test
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/azukds/tubular/security/code-scanning/2](https://github.com/azukds/tubular/security/code-scanning/2)

In general, this issue is fixed by explicitly specifying a `permissions:` block in the workflow (either at the top level to apply to all jobs, or within each job) to restrict the `GITHUB_TOKEN` to the minimal scopes required. For this workflow, both `build` and `lint` jobs only need to read repository contents and upload artifacts; they do not need to modify repo data via the GitHub API, so `contents: read` is sufficient.

The best minimal-change fix is to add a single top-level `permissions:` block alongside `name:` and `on:` so it applies to all jobs. No existing functionality will break because none of the jobs rely on elevated token scopes. Concretely, in `.github/workflows/python-package.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name:` and `on:` keys (or directly under `name:` with correct indentation). No imports or additional definitions are needed; this is purely a YAML configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
