### PR TITLE
Feature/align output medianimputer

### DIFF
--- a/tests/imputers/test_MedianImputer.py
+++ b/tests/imputers/test_MedianImputer.py
@@ -89,7 +89,7 @@ class TestFit(WeightColumnFitMixinTests, GenericFitTests):
         transformer.fit(df)
 
         assert transformer.impute_values_ == {
-            "a": np.int64(4),
+            "a": np.float64(4.2),
             "d": None,
         }, "impute_values_ attribute"
 

--- a/tubular/_stats.py
+++ b/tubular/_stats.py
@@ -42,23 +42,12 @@ def _get_median_calculation_expression(
         weighted_quantile_expr = _weighted_quantile_expr(initial_weights_expr)
 
         QUANTILE_50 = 0.5
-        x1 = initial_column_expr.filter(
-            weighted_quantile_expr < QUANTILE_50
-        ).max()
-        x2 = initial_column_expr.filter(
-            weighted_quantile_expr >= QUANTILE_50
-        ).min()
-        w1 = weighted_quantile_expr.filter(
-            weighted_quantile_expr < QUANTILE_50
-        ).max()
-        w2 = weighted_quantile_expr.filter(
-            weighted_quantile_expr >= QUANTILE_50
-        ).min()
-        median_expr1  = initial_column_expr.filter(
-            weighted_quantile_expr >= QUANTILE_50
-        ).min()
-        median_expr = x1 +  (x2 - x1) / (w2 - w1) * (0.5 - w1)
+        x1 = initial_column_expr.filter(weighted_quantile_expr < QUANTILE_50).max()
+        x2 = initial_column_expr.filter(weighted_quantile_expr >= QUANTILE_50).min()
+        w1 = weighted_quantile_expr.filter(weighted_quantile_expr < QUANTILE_50).max()
+        w2 = weighted_quantile_expr.filter(weighted_quantile_expr >= QUANTILE_50).min()
 
+        median_expr = x1 + ((x2 - x1) / (w2 - w1)) * (0.5 - w1)
 
     else:
         median_expr = initial_column_expr.drop_nulls().median()
@@ -257,13 +246,15 @@ def _weighted_quantile_expr(
     |  │ ---      │    |
     |  │ f64      │    |
     |  ╞══════════╡    |
-    |  │ 0.166667 │    |
-    |  │ 0.5      │    |
-    |  │ 1.0      │    |
+    |  │ 0.083333 │    |
+    |  │ 0.333333 │    |
+    |  │ 0.75     │    |
     |  └──────────┘    |
     └──────────────────┘
 
     ```
 
     """
-    return (initial_weights_expr.cum_sum() - 0.5 * initial_weights_expr) / initial_weights_expr.sum()
+    return (
+        initial_weights_expr.cum_sum() - 0.5 * initial_weights_expr
+    ) / initial_weights_expr.sum()


### PR DESCRIPTION
Below error is thrown for .over() method that is called at the end to broadcast the scalar value sum back to the original length.

NotImplementedError: Only elementary expressions are supported for `.over` in pandas-like backends when `partition_by` is specified.