### PR TITLE
Allow y parameter to accept pl.LazyFrame for maximum efficiency

### DIFF
--- a/tests/capping/test_CappingTransformer.py
+++ b/tests/capping/test_CappingTransformer.py
@@ -7,7 +7,7 @@ from tests.capping.test_BaseCappingTransformer import (
     GenericCappingInitTests,
     GenericCappingTransformTests,
 )
-from tests.utils import dataframe_init_dispatch
+from tests.utils import assert_frame_equal_dispatch, dataframe_init_dispatch
 from tubular.capping import CappingTransformer
 
 
@@ -48,8 +48,20 @@ class TestLazyYSupport:
 
         transformer = CappingTransformer(quantiles={"b": [0.1, 0.9]})
 
-        # Should not raise an error
+        # Fit should accept lazy y and not raise an error
         transformer.fit(df, y_lazy)
+
+        # Transform should apply caps correctly based on learned quantiles
+        expected = pl.DataFrame(
+            {
+                "a": [1, 2, 3, 4, 5],
+                "b": [1.0, 2.0, 3.0, 4.0, 4.5],
+            }
+        )
+
+        transformed = transformer.transform(df)
+
+        assert_frame_equal_dispatch(transformed, expected)
 
 
 class TestOtherBaseBehaviour(

--- a/tests/capping/test_CappingTransformer.py
+++ b/tests/capping/test_CappingTransformer.py
@@ -1,3 +1,4 @@
+import polars as pl
 import pytest
 
 from tests.base_tests import EmptyCappingsFitTransformPassTests, OtherBaseBehaviourTests
@@ -6,6 +7,8 @@ from tests.capping.test_BaseCappingTransformer import (
     GenericCappingInitTests,
     GenericCappingTransformTests,
 )
+from tests.utils import dataframe_init_dispatch
+from tubular.capping import CappingTransformer
 
 
 class TestInit(GenericCappingInitTests):
@@ -30,6 +33,23 @@ class TestTransform(GenericCappingTransformTests):
     @classmethod
     def setup_class(cls):
         cls.transformer_name = "CappingTransformer"
+
+
+class TestLazyYSupport:
+    """Tests for lazy y support in CappingTransformer."""
+
+    @pytest.mark.parametrize("library", ["polars"])
+    def test_lazy_y_accepted(self, library):
+        """Test that CappingTransformer accepts LazyFrame for y parameter."""
+        df_dict = {"a": [1, 2, 3, 4, 5], "b": [1.0, 2.0, 3.0, 4.0, 5.0]}
+        df = dataframe_init_dispatch(df_dict, library)
+
+        y_lazy = pl.LazyFrame({"a": [1, 2, 3, 4, 5]})
+
+        transformer = CappingTransformer(quantiles={"b": [0.1, 0.9]})
+
+        # Should not raise an error
+        transformer.fit(df, y_lazy)
 
 
 class TestOtherBaseBehaviour(

--- a/tests/capping/test_OutOfRangeNullTransformer.py
+++ b/tests/capping/test_OutOfRangeNullTransformer.py
@@ -1,4 +1,5 @@
 import narwhals as nw
+import polars as pl
 import pytest
 
 import tests.test_data as d
@@ -150,6 +151,25 @@ class TestTransform(GenericCappingTransformTests):
                 _collect_frame(df_transformed_row, lazy),
                 df_expected_row,
             )
+
+
+class TestLazyYSupport:
+    """Tests for lazy y support in OutOfRangeNullTransformer."""
+
+    @pytest.mark.parametrize("library", ["polars"])
+    def test_lazy_y_accepted(self, library):
+        """Test that OutOfRangeNullTransformer accepts LazyFrame for y parameter."""
+        df_dict = {"a": [1, 2, 3, 4, 5], "b": [1.0, 2.0, 3.0, 4.0, 5.0]}
+        df = dataframe_init_dispatch(df_dict, library)
+
+        y_lazy = pl.LazyFrame({"a": [1, 2, 3, 4, 5]})
+
+        transformer = OutOfRangeNullTransformer(
+            quantiles={"a": [0.1, 0.9], "b": [0.1, 0.9]}
+        )
+
+        # Should not raise an error
+        transformer.fit(df, y_lazy)
 
 
 class TestOtherBaseBehaviour(

--- a/tests/capping/test_OutOfRangeNullTransformer.py
+++ b/tests/capping/test_OutOfRangeNullTransformer.py
@@ -168,8 +168,19 @@ class TestLazyYSupport:
             quantiles={"a": [0.1, 0.9], "b": [0.1, 0.9]}
         )
 
-        # Should not raise an error
+        # Fit should accept lazy y and not raise an error
         transformer.fit(df, y_lazy)
+
+        expected = pl.DataFrame(
+            {
+                "a": [1, 2, 3, 4, None],
+                "b": [1.0, 2.0, 3.0, 4.0, None],
+            }
+        )
+
+        transformed = transformer.transform(df)
+
+        assert_frame_equal_dispatch(transformed, expected)
 
 
 class TestOtherBaseBehaviour(

--- a/tests/imputers/test_MeanImputer.py
+++ b/tests/imputers/test_MeanImputer.py
@@ -17,7 +17,11 @@ from tests.imputers.test_BaseImputer import (
     GenericImputerTransformTests,
     GenericImputerTransformTestsWeight,
 )
-from tests.utils import _convert_to_lazy, dataframe_init_dispatch
+from tests.utils import (
+    _convert_to_lazy,
+    assert_frame_equal_dispatch,
+    dataframe_init_dispatch,
+)
 from tubular.imputers import MeanImputer
 
 
@@ -102,8 +106,17 @@ class TestLazyYSupport:
 
         transformer = MeanImputer(columns="b")
 
-        # Should not raise an error
+        # Fit should accept lazy y and not raise an error
         transformer.fit(df, y_lazy)
+
+        expected = dataframe_init_dispatch(
+            {"a": [1, 2, 3, 4, 5], "b": [1.0, 2.0, 3.0, 4.0, 5.0]},
+            library,
+        )
+
+        transformed = transformer.transform(df)
+
+        assert_frame_equal_dispatch(transformed, expected)
 
 
 class TestOtherBaseBehaviour(

--- a/tests/imputers/test_MeanImputer.py
+++ b/tests/imputers/test_MeanImputer.py
@@ -1,3 +1,4 @@
+import polars as pl
 import pytest
 
 import tests.test_data as d
@@ -16,9 +17,7 @@ from tests.imputers.test_BaseImputer import (
     GenericImputerTransformTests,
     GenericImputerTransformTestsWeight,
 )
-from tests.utils import (
-    _convert_to_lazy,
-)
+from tests.utils import _convert_to_lazy, dataframe_init_dispatch
 from tubular.imputers import MeanImputer
 
 
@@ -88,6 +87,23 @@ class TestTransform(
     @classmethod
     def setup_class(cls):
         cls.transformer_name = "MeanImputer"
+
+
+class TestLazyYSupport:
+    """Tests for lazy y support in MeanImputer."""
+
+    @pytest.mark.parametrize("library", ["polars"])
+    def test_lazy_y_accepted(self, library):
+        """Test that MeanImputer accepts LazyFrame for y parameter."""
+        df_dict = {"a": [1, 2, 3, 4, 5], "b": [1.0, 2.0, None, 4.0, 5.0]}
+        df = dataframe_init_dispatch(df_dict, library)
+
+        y_lazy = pl.LazyFrame({"a": [1, 2, 3, 4, 5]})
+
+        transformer = MeanImputer(columns="b")
+
+        # Should not raise an error
+        transformer.fit(df, y_lazy)
 
 
 class TestOtherBaseBehaviour(

--- a/tests/imputers/test_MedianImputer.py
+++ b/tests/imputers/test_MedianImputer.py
@@ -19,7 +19,7 @@ from tests.imputers.test_BaseImputer import (
     GenericImputerTransformTests,
     GenericImputerTransformTestsWeight,
 )
-from tests.utils import dataframe_init_dispatch
+from tests.utils import assert_frame_equal_dispatch, dataframe_init_dispatch
 from tubular.imputers import MedianImputer
 
 
@@ -95,8 +95,17 @@ class TestLazyYSupport:
 
         transformer = MedianImputer(columns="b")
 
-        # Should not raise an error
+        # Fit should accept lazy y and not raise an error
         transformer.fit(df, y_lazy)
+
+        expected = dataframe_init_dispatch(
+            {"a": [1, 2, 3, 4, 5], "b": [1.0, 2.0, 3.0, 4.0, 5.0]},
+            library,
+        )
+
+        transformed = transformer.transform(df)
+
+        assert_frame_equal_dispatch(transformed, expected)
 
 
 class TestOtherBaseBehaviour(

--- a/tests/imputers/test_MedianImputer.py
+++ b/tests/imputers/test_MedianImputer.py
@@ -1,4 +1,5 @@
 import numpy as np
+import polars as pl
 import pytest
 
 import tests.test_data as d
@@ -18,6 +19,7 @@ from tests.imputers.test_BaseImputer import (
     GenericImputerTransformTests,
     GenericImputerTransformTestsWeight,
 )
+from tests.utils import dataframe_init_dispatch
 from tubular.imputers import MedianImputer
 
 
@@ -78,6 +80,23 @@ class TestTransform(
     @classmethod
     def setup_class(cls):
         cls.transformer_name = "MedianImputer"
+
+
+class TestLazyYSupport:
+    """Tests for lazy y support in MedianImputer."""
+
+    @pytest.mark.parametrize("library", ["polars"])
+    def test_lazy_y_accepted(self, library):
+        """Test that MedianImputer accepts LazyFrame for y parameter."""
+        df_dict = {"a": [1, 2, 3, 4, 5], "b": [1.0, 2.0, None, 4.0, 5.0]}
+        df = dataframe_init_dispatch(df_dict, library)
+
+        y_lazy = pl.LazyFrame({"a": [1, 2, 3, 4, 5]})
+
+        transformer = MedianImputer(columns="b")
+
+        # Should not raise an error
+        transformer.fit(df, y_lazy)
 
 
 class TestOtherBaseBehaviour(

--- a/tests/imputers/test_ModeImputer.py
+++ b/tests/imputers/test_ModeImputer.py
@@ -1,5 +1,6 @@
 import narwhals as nw
 import numpy as np
+import polars as pl
 import pytest
 
 from tests.base_tests import (
@@ -281,6 +282,23 @@ class TestTransform(
     @classmethod
     def setup_class(cls):
         cls.transformer_name = "ModeImputer"
+
+
+class TestLazyYSupport:
+    """Tests for lazy y support in ModeImputer."""
+
+    @pytest.mark.parametrize("library", ["polars"])
+    def test_lazy_y_accepted(self, library):
+        """Test that ModeImputer accepts LazyFrame for y parameter."""
+        df_dict = {"a": [1, 2, 3, 4, 5], "b": ["x", "y", "z", "x", "y"]}
+        df = dataframe_init_dispatch(df_dict, library)
+
+        y_lazy = pl.LazyFrame({"a": [1, 2, 3, 4, 5]})
+
+        transformer = ModeImputer(columns="b")
+
+        # Should not raise an error
+        transformer.fit(df, y_lazy)
 
 
 class TestOtherBaseBehaviour(

--- a/tests/imputers/test_ModeImputer.py
+++ b/tests/imputers/test_ModeImputer.py
@@ -291,7 +291,7 @@ class TestLazyYSupport:
     @pytest.mark.parametrize("library", ["polars"])
     def test_lazy_y_accepted(self, library):
         """Test that ModeImputer accepts LazyFrame for y parameter."""
-        df_dict = {"a": [1, 2, 3, 4, 5], "b": ["x", "y", "z", "x", "y"]}
+        df_dict = {"a": [1, 2, 3, 4, 5], "b": ["x", "y", "x", "x", None]}
         df = dataframe_init_dispatch(df_dict, library)
 
         y_lazy = pl.LazyFrame({"a": [1, 2, 3, 4, 5]})
@@ -303,7 +303,7 @@ class TestLazyYSupport:
 
         # Transform should work correctly (no nulls to impute, so unchanged)
         expected = dataframe_init_dispatch(
-            {"a": [1, 2, 3, 4, 5], "b": ["x", "y", "z", "x", "y"]},
+            {"a": [1, 2, 3, 4, 5], "b": ["x", "y", "x", "x", "x"]},
             library,
         )
 

--- a/tests/imputers/test_ModeImputer.py
+++ b/tests/imputers/test_ModeImputer.py
@@ -20,6 +20,7 @@ from tests.imputers.test_BaseImputer import (
 )
 from tests.utils import (
     _convert_to_lazy,
+    assert_frame_equal_dispatch,
     dataframe_init_dispatch,
 )
 from tubular.imputers import ModeImputer
@@ -297,8 +298,18 @@ class TestLazyYSupport:
 
         transformer = ModeImputer(columns="b")
 
-        # Should not raise an error
+        # Fit should accept lazy y and not raise an error
         transformer.fit(df, y_lazy)
+
+        # Transform should work correctly (no nulls to impute, so unchanged)
+        expected = dataframe_init_dispatch(
+            {"a": [1, 2, 3, 4, 5], "b": ["x", "y", "z", "x", "y"]},
+            library,
+        )
+
+        transformed = transformer.transform(df)
+
+        assert_frame_equal_dispatch(transformed, expected)
 
 
 class TestOtherBaseBehaviour(

--- a/tests/nominal/test_GroupRareLevelsTransformer.py
+++ b/tests/nominal/test_GroupRareLevelsTransformer.py
@@ -529,10 +529,37 @@ class TestLazyYSupport:
 
         y_lazy = pl.LazyFrame({"a": list(range(10))})
 
-        transformer = GroupRareLevelsTransformer(columns=["b", "c"])
+        transformer = GroupRareLevelsTransformer(
+            columns=["b", "c"], cut_off_percent=0.2
+        )
 
-        # Should not raise an error
+        # Fit should accept lazy y and not raise an error
         transformer.fit(df, y_lazy)
+
+        # Transform should group rare levels correctly
+        expected = dataframe_init_dispatch(
+            {
+                "a": [2, 2, 2, 2, 0, 2, 2, 2, 3, 3],
+                "b": [
+                    "a",
+                    "a",
+                    "a",
+                    "rare",
+                    "rare",
+                    "rare",
+                    "rare",
+                    "rare",
+                    "rare",
+                    "rare",
+                ],
+                "c": ["rare", "rare", "rare", "rare", "f", "f", "f", "g", "g", "rare"],
+            },
+            library,
+        )
+
+        transformed = transformer.transform(df)
+
+        assert_frame_equal_dispatch(transformed, expected)
 
 
 class TestOtherBaseBehaviour(

--- a/tests/nominal/test_GroupRareLevelsTransformer.py
+++ b/tests/nominal/test_GroupRareLevelsTransformer.py
@@ -1,6 +1,7 @@
 import re
 
 import narwhals as nw
+import polars as pl
 import pytest
 from beartype.roar import BeartypeCallHintParamViolation
 from test_BaseNominalTransformer import (
@@ -511,6 +512,27 @@ class TestTransform(GenericNominalTransformTests):
             assert cat not in output_categories, (
                 f"{transformer.classname} output columns should forget rare encoded categories, expected {cat} to be forgotten from column {column}"
             )
+
+
+class TestLazyYSupport:
+    """Tests for lazy y support in GroupRareLevelsTransformer."""
+
+    @pytest.mark.parametrize("library", ["polars"])
+    def test_lazy_y_accepted(self, library):
+        """Test that GroupRareLevelsTransformer accepts LazyFrame for y parameter."""
+        df_dict = {
+            "a": [2, 2, 2, 2, 0, 2, 2, 2, 3, 3],
+            "b": ["a", "a", "a", "d", "e", "f", "g", "h", "i", "j"],
+            "c": ["a", "b", "c", "d", "f", "f", "f", "g", "g", "k"],
+        }
+        df = dataframe_init_dispatch(df_dict, library)
+
+        y_lazy = pl.LazyFrame({"a": list(range(10))})
+
+        transformer = GroupRareLevelsTransformer(columns=["b", "c"])
+
+        # Should not raise an error
+        transformer.fit(df, y_lazy)
 
 
 class TestOtherBaseBehaviour(

--- a/tests/nominal/test_MeanResponseTransformer.py
+++ b/tests/nominal/test_MeanResponseTransformer.py
@@ -1396,3 +1396,28 @@ class TestOtherBaseBehaviour(
     @classmethod
     def setup_class(cls):
         cls.transformer_name = "MeanResponseTransformer"
+
+
+class TestLazyYSupport:
+    """Tests for lazy y parameter support in MeanResponseTransformer."""
+
+    @pytest.mark.parametrize("library", ["polars"])
+    def test_lazy_y_support(self, library):
+        """Test that MeanResponseTransformer accepts LazyFrame as y parameter."""
+        df = create_MeanResponseTransformer_test_df(library=library)
+
+        # Create lazy y
+        y_lazy = nw.from_native(df["a"].to_frame().lazy(), allow_series=False)
+
+        x = MeanResponseTransformer(columns="b")
+
+        # Should not raise an error
+        x.fit(df, y_lazy)
+
+        # Verify mappings were created correctly
+        assert "b" in x.mappings
+        assert len(x.mappings["b"]) > 0
+
+        # Test transform works
+        result = x.transform(df)
+        assert result is not None

--- a/tests/nominal/test_MeanResponseTransformer.py
+++ b/tests/nominal/test_MeanResponseTransformer.py
@@ -1396,28 +1396,3 @@ class TestOtherBaseBehaviour(
     @classmethod
     def setup_class(cls):
         cls.transformer_name = "MeanResponseTransformer"
-
-
-class TestLazyYSupport:
-    """Tests for lazy y parameter support in MeanResponseTransformer."""
-
-    @pytest.mark.parametrize("library", ["polars"])
-    def test_lazy_y_support(self, library):
-        """Test that MeanResponseTransformer accepts LazyFrame as y parameter."""
-        df = create_MeanResponseTransformer_test_df(library=library)
-
-        # Create lazy y
-        y_lazy = nw.from_native(df["a"].to_frame().lazy(), allow_series=False)
-
-        x = MeanResponseTransformer(columns="b")
-
-        # Should not raise an error
-        x.fit(df, y_lazy)
-
-        # Verify mappings were created correctly
-        assert "b" in x.mappings
-        assert len(x.mappings["b"]) > 0
-
-        # Test transform works
-        result = x.transform(df)
-        assert result is not None

--- a/tests/nominal/test_OneHotEncodingTransformer.py
+++ b/tests/nominal/test_OneHotEncodingTransformer.py
@@ -535,15 +535,34 @@ class TestLazyYSupport:
     @pytest.mark.parametrize("library", ["polars"])
     def test_lazy_y_accepted(self, library):
         """Test that OneHotEncodingTransformer accepts LazyFrame for y parameter."""
+        # Create a sample DataFrame
         df_dict = {"a": ["x", "y", "z"], "b": [1, 2, 3]}
         df = dataframe_init_dispatch(df_dict, library)
 
+        # Create a LazyFrame for y
         y_lazy = pl.LazyFrame({"b": [1, 2, 3]})
 
-        transformer = OneHotEncodingTransformer(columns="a")
+        # Initialise the transformer with drop_original=True
+        transformer = OneHotEncodingTransformer(columns="a", drop_original=True)
 
-        # Should not raise an error
+        # Fit should accept lazy y and not raise an error
         transformer.fit(df, y_lazy)
+
+        # Create the expected DataFrame
+        expected = pl.DataFrame(
+            {
+                "b": [1, 2, 3],
+                "a_x": [True, False, False],
+                "a_y": [False, True, False],
+                "a_z": [False, False, True],
+            }
+        )
+
+        # Transform the input DataFrame
+        transformed = transformer.transform(df)
+
+        # Assert that the transformed DataFrame matches the expected DataFrame
+        assert_frame_equal_dispatch(transformed, expected)
 
 
 class TestOtherBaseBehaviour(

--- a/tests/nominal/test_OneHotEncodingTransformer.py
+++ b/tests/nominal/test_OneHotEncodingTransformer.py
@@ -1,5 +1,6 @@
 import narwhals as nw
 import numpy as np
+import polars as pl
 import pytest
 from beartype.roar import BeartypeCallHintParamViolation
 from test_BaseNominalTransformer import GenericNominalTransformTests
@@ -526,6 +527,23 @@ class TestTransform(
         assert_frame_equal_dispatch(
             _collect_frame(df_transformed, lazy=lazy), expected_df.to_native()
         )
+
+
+class TestLazyYSupport:
+    """Tests for lazy y support in OneHotEncodingTransformer."""
+
+    @pytest.mark.parametrize("library", ["polars"])
+    def test_lazy_y_accepted(self, library):
+        """Test that OneHotEncodingTransformer accepts LazyFrame for y parameter."""
+        df_dict = {"a": ["x", "y", "z"], "b": [1, 2, 3]}
+        df = dataframe_init_dispatch(df_dict, library)
+
+        y_lazy = pl.LazyFrame({"b": [1, 2, 3]})
+
+        transformer = OneHotEncodingTransformer(columns="a")
+
+        # Should not raise an error
+        transformer.fit(df, y_lazy)
 
 
 class TestOtherBaseBehaviour(

--- a/tubular/_utils.py
+++ b/tubular/_utils.py
@@ -56,6 +56,39 @@ def _convert_dataframe_to_narwhals(X: DataFrame) -> NarwhalsFrame:
 
 
 @beartype
+def _collect_series(y: nw.Series | nw.LazyFrame | None = None) -> nw.Series | None:
+    """Collect lazy series/frames, or return inputs if eager.
+
+    Parameters
+    ----------
+    y: nw.Series or nw.LazyFrame
+        Series or LazyFrame to be collected if lazy
+
+    Returns
+    -------
+    nw.Series: collected series
+
+    """
+    if y is None:
+        return None
+
+    if isinstance(y, nw.LazyFrame):
+        # Convert LazyFrame to native, collect, then back to narwhals Series
+        native_lazy = y.to_native()
+        collected = native_lazy.collect()
+        # Get the first column as a Series
+        if hasattr(collected, "columns"):
+            first_col = collected.columns[0]
+            series_native = collected[first_col]
+            y = nw.from_native(series_native, allow_series=True)
+        else:
+            # If it's already a Series, just convert it
+            y = nw.from_native(collected, allow_series=True)
+
+    return y
+
+
+@beartype
 def _convert_series_to_narwhals(
     y: Series | None = None,
 ) -> nw.Series | nw.LazyFrame | None:

--- a/tubular/_utils.py
+++ b/tubular/_utils.py
@@ -73,17 +73,11 @@ def _collect_series(y: nw.Series | nw.LazyFrame | None = None) -> nw.Series | No
         return None
 
     if isinstance(y, nw.LazyFrame):
-        # Convert LazyFrame to native, collect, then back to narwhals Series
-        native_lazy = y.to_native()
-        collected = native_lazy.collect()
+        # Collect directly without converting to native first
+        collected_df = y.collect()
         # Get the first column as a Series
-        if hasattr(collected, "columns"):
-            first_col = collected.columns[0]
-            series_native = collected[first_col]
-            y = nw.from_native(series_native, allow_series=True)
-        else:
-            # If it's already a Series, just convert it
-            y = nw.from_native(collected, allow_series=True)
+        col_name = collected_df.columns[0]
+        y = collected_df.get_column(col_name)
 
     return y
 

--- a/tubular/_utils.py
+++ b/tubular/_utils.py
@@ -56,7 +56,9 @@ def _convert_dataframe_to_narwhals(X: DataFrame) -> NarwhalsFrame:
 
 
 @beartype
-def _convert_series_to_narwhals(y: Series | None = None) -> nw.Series | None:
+def _convert_series_to_narwhals(
+    y: Series | None = None,
+) -> nw.Series | nw.LazyFrame | None:
     """Narwhalifies series, if series is not already narwhals.
 
     Parameters
@@ -69,7 +71,7 @@ def _convert_series_to_narwhals(y: Series | None = None) -> nw.Series | None:
     nw.Series: narwhalified series
 
     """
-    if y is not None and not isinstance(y, nw.Series):
+    if y is not None and not isinstance(y, (nw.Series, nw.LazyFrame)):
         y = nw.from_native(y, allow_series=True)
 
     return y

--- a/tubular/_utils.py
+++ b/tubular/_utils.py
@@ -76,7 +76,7 @@ def _collect_series(y: nw.Series | nw.LazyFrame | None = None) -> nw.Series | No
         # Collect directly without converting to native first
         collected_df = y.collect()
         # Get the first column as a Series
-        col_name = collected_df.columns[0]
+        col_name = collected_df.collect_schema().names()[0]
         y = collected_df.get_column(col_name)
 
     return y

--- a/tubular/_utils.py
+++ b/tubular/_utils.py
@@ -12,7 +12,7 @@ from beartype import beartype
 from narwhals.typing import IntoDType
 from numpy.typing import ArrayLike
 
-from tubular.types import DataFrame, NarwhalsFrame, Series
+from tubular.types import DataFrame, LazyFrame, NarwhalsFrame, Series
 
 
 @beartype
@@ -84,7 +84,7 @@ def _collect_series(y: nw.Series | nw.LazyFrame | None = None) -> nw.Series | No
 
 @beartype
 def _convert_series_to_narwhals(
-    y: Series | None = None,
+    y: Series | LazyFrame | None = None,
 ) -> nw.Series | nw.LazyFrame | None:
     """Narwhalifies series, if series is not already narwhals.
 

--- a/tubular/base.py
+++ b/tubular/base.py
@@ -25,6 +25,7 @@ from tubular.mixins import DropOriginalMixin
 from tubular.types import (
     DataFrame,
     GenericKwargs,
+    LazyFrame,
     ListOfStrs,
     NonEmptyListOfStrs,
     Series,
@@ -323,7 +324,7 @@ class BaseTransformer(BaseEstimator, TransformerMixin):
 
     @block_from_json
     @beartype
-    def fit(self, X: DataFrame, y: Series | None = None) -> BaseTransformer:
+    def fit(self, X: DataFrame, y: Series | LazyFrame | None = None) -> BaseTransformer:
         """Check data before fit.
 
         Fit calls the columns_check method which will check that the columns
@@ -334,7 +335,7 @@ class BaseTransformer(BaseEstimator, TransformerMixin):
         X : DataFrame
             Data to fit the transformer on.
 
-        y : None or Series, default = None
+        y : None or Series or LazyFrame, default = None
             Optional argument only required for the transformer to work with sklearn
             pipelines.
 

--- a/tubular/base.py
+++ b/tubular/base.py
@@ -370,7 +370,7 @@ class BaseTransformer(BaseEstimator, TransformerMixin):
     @block_from_json
     @beartype
     def _combine_X_y(
-        self, X: DataFrame, y: Series, return_native_override: bool = True
+        self, X: DataFrame, y: Series | LazyFrame, return_native_override: bool = True
     ) -> DataFrame:
         """Combine X and y by adding a new column with the values of y to a copy of X.
 
@@ -384,7 +384,7 @@ class BaseTransformer(BaseEstimator, TransformerMixin):
         X : DataFrame
             Data containing explanatory variables.
 
-        y : Series
+        y : Series or LazyFrame
             Response variable.
 
         return_native_override: Optional[bool]
@@ -433,7 +433,23 @@ class BaseTransformer(BaseEstimator, TransformerMixin):
 
         return_native = self._process_return_native(return_native_override)
 
-        X = X.with_columns(_temporary_response=y)
+        # If both X and y are LazyFrames, use join to maintain lazy evaluation
+        if isinstance(X, nw.LazyFrame) and isinstance(y, nw.LazyFrame):
+            # Convert LazyFrame y to LazyFrame with row index for joining
+            y_named = y.with_row_index("__row_idx__")
+            X_indexed = X.with_row_index("__row_idx__")
+            y_col = y.columns[0]
+            X = (
+                X_indexed.join(
+                    y_named.select("__row_idx__", y_col), on="__row_idx__", how="inner"
+                )
+                .select("*")
+                .exclude("__row_idx__")
+                .rename({y_col: "_temporary_response"})
+            )
+        else:
+            # For eager frames or Series, use with_columns
+            X = X.with_columns(_temporary_response=y)
 
         return _return_narwhals_or_native_dataframe(X, return_native)
 

--- a/tubular/base.py
+++ b/tubular/base.py
@@ -15,6 +15,7 @@ from sklearn.utils.validation import check_is_fitted
 from typing_extensions import deprecated
 
 from tubular._utils import (
+    _collect_series,
     _convert_dataframe_to_narwhals,
     _convert_series_to_narwhals,
     _get_version,
@@ -447,6 +448,10 @@ class BaseTransformer(BaseEstimator, TransformerMixin):
                 .exclude("__row_idx__")
                 .rename({y_col: "_temporary_response"})
             )
+        elif isinstance(y, nw.LazyFrame):
+            # If y is LazyFrame but X is not, collect y first
+            y = _collect_series(y)
+            X = X.with_columns(_temporary_response=y)
         else:
             # For eager frames or Series, use with_columns
             X = X.with_columns(_temporary_response=y)

--- a/tubular/capping.py
+++ b/tubular/capping.py
@@ -21,7 +21,7 @@ from tubular._utils import (
 from tubular.base import block_from_json, register
 from tubular.mixins import WeightColumnMixin
 from tubular.numeric import BaseNumericTransformer
-from tubular.types import DataFrame, Number, Series
+from tubular.types import DataFrame, LazyFrame, Number, Series
 
 CappingValues = Annotated[
     list[Number | None],
@@ -246,7 +246,10 @@ class BaseCappingTransformer(BaseNumericTransformer, WeightColumnMixin):
 
     @block_from_json
     @beartype
-    def fit(self, X: DataFrame, y: Series | None = None) -> BaseCappingTransformer:
+    @beartype
+    def fit(
+        self, X: DataFrame, y: Series | LazyFrame | None = None
+    ) -> BaseCappingTransformer:
         """Learn capping values from input data X.
 
         Calculates the quantiles to cap at given the quantiles dictionary supplied
@@ -258,7 +261,7 @@ class BaseCappingTransformer(BaseNumericTransformer, WeightColumnMixin):
         X : DataFrame
             A dataframe with required columns to be capped.
 
-        y : Series or None. Defaults to None
+        y : Series or LazyFrame or None. Defaults to None
             Required for pipeline.
 
         Returns
@@ -745,7 +748,9 @@ class CappingTransformer(BaseCappingTransformer):
 
     @block_from_json
     @beartype
-    def fit(self, X: DataFrame, y: Series | None = None) -> CappingTransformer:
+    def fit(
+        self, X: DataFrame, y: Series | LazyFrame | None = None
+    ) -> CappingTransformer:
         """Learn capping values from input data X.
 
         Calculates the quantiles to cap at given the quantiles dictionary supplied
@@ -971,7 +976,9 @@ class OutOfRangeNullTransformer(BaseCappingTransformer):
 
     @block_from_json
     @beartype
-    def fit(self, X: DataFrame, y: Series | None = None) -> OutOfRangeNullTransformer:
+    def fit(
+        self, X: DataFrame, y: Series | LazyFrame | None = None
+    ) -> OutOfRangeNullTransformer:
         """Learn capping values from input data X.
 
         Calculates the quantiles to cap at given the quantiles dictionary supplied

--- a/tubular/imputers.py
+++ b/tubular/imputers.py
@@ -16,7 +16,6 @@ from tubular._stats import (
 )
 from tubular._utils import (
     _collect_frame,
-    _collect_series,
     _convert_dataframe_to_narwhals,
     _convert_series_to_narwhals,
     _is_null,
@@ -1607,9 +1606,6 @@ class NearestMeanResponseImputer(BaseImputer):
         y = _convert_series_to_narwhals(y)
 
         super().fit(X, y)
-
-        # Collect lazy y to enable operations like .is_null().sum()
-        y = _collect_series(y)
 
         if (n_nulls := y.is_null().sum()) > 0:
             msg = f"{self.classname()}: y has {n_nulls} null values"

--- a/tubular/imputers.py
+++ b/tubular/imputers.py
@@ -1581,7 +1581,7 @@ class NearestMeanResponseImputer(BaseImputer):
         super().__init__(columns=columns, **kwargs)
 
     @beartype
-    def fit(self, X: DataFrame, y: Series | LazyFrame) -> NearestMeanResponseImputer:
+    def fit(self, X: DataFrame, y: Series) -> NearestMeanResponseImputer:
         """Calculate mean values to impute with.
 
         Parameters

--- a/tubular/imputers.py
+++ b/tubular/imputers.py
@@ -16,6 +16,7 @@ from tubular._stats import (
 )
 from tubular._utils import (
     _collect_frame,
+    _collect_series,
     _convert_dataframe_to_narwhals,
     _convert_series_to_narwhals,
     _is_null,
@@ -1606,6 +1607,9 @@ class NearestMeanResponseImputer(BaseImputer):
         y = _convert_series_to_narwhals(y)
 
         super().fit(X, y)
+
+        # Collect lazy y to enable operations like .is_null().sum()
+        y = _collect_series(y)
 
         if (n_nulls := y.is_null().sum()) > 0:
             msg = f"{self.classname()}: y has {n_nulls} null values"

--- a/tubular/imputers.py
+++ b/tubular/imputers.py
@@ -25,7 +25,7 @@ from tubular._utils import (
 )
 from tubular.base import BaseTransformer, register
 from tubular.mixins import WeightColumnMixin
-from tubular.types import DataFrame, ListOfStrs, NumericTypes, Series
+from tubular.types import DataFrame, LazyFrame, ListOfStrs, NumericTypes, Series
 
 pl.enable_string_cache()
 
@@ -931,7 +931,7 @@ class MedianImputer(BaseImputer, WeightColumnMixin):
 
     @block_from_json
     @beartype
-    def fit(self, X: DataFrame, y: Series | None = None) -> MedianImputer:
+    def fit(self, X: DataFrame, y: Series | LazyFrame | None = None) -> MedianImputer:
         """Calculate median values to impute with from X.
 
         Parameters
@@ -939,7 +939,7 @@ class MedianImputer(BaseImputer, WeightColumnMixin):
         X : DataFrame
             Data to "learn" the median values from.
 
-        y : Series or None, default = None
+        y : Series or LazyFrame or None, default = None
             Not required.
 
         Returns
@@ -1117,7 +1117,7 @@ class MeanImputer(WeightColumnMixin, BaseImputer):
 
     @block_from_json
     @beartype
-    def fit(self, X: DataFrame, y: Series | None = None) -> MeanImputer:
+    def fit(self, X: DataFrame, y: Series | LazyFrame | None = None) -> MeanImputer:
         """Calculate mean values to impute with from X.
 
         Parameters
@@ -1125,7 +1125,7 @@ class MeanImputer(WeightColumnMixin, BaseImputer):
         X : DataFrame
             Data to "learn" the mean values from.
 
-        y : Series or None, default = None
+        y : Series or LazyFrame or None, default = None
             Not required.
 
         Returns
@@ -1291,7 +1291,7 @@ class ModeImputer(BaseImputer, WeightColumnMixin):
 
     @block_from_json
     @beartype
-    def fit(self, X: DataFrame, y: Series | None = None) -> ModeImputer:
+    def fit(self, X: DataFrame, y: Series | LazyFrame | None = None) -> ModeImputer:
         """Calculate mode values to impute with from X.
 
         In the event of a tie, the highest modal value will be returned.
@@ -1301,7 +1301,7 @@ class ModeImputer(BaseImputer, WeightColumnMixin):
         X : DataFrame
             Data to "learn" the mode values from.
 
-        y : Series or None, default = None
+        y : Series or LazyFrame or None, default = None
             Not required.
 
         Returns
@@ -1581,7 +1581,7 @@ class NearestMeanResponseImputer(BaseImputer):
         super().__init__(columns=columns, **kwargs)
 
     @beartype
-    def fit(self, X: DataFrame, y: Series) -> NearestMeanResponseImputer:
+    def fit(self, X: DataFrame, y: Series | LazyFrame) -> NearestMeanResponseImputer:
         """Calculate mean values to impute with.
 
         Parameters

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -31,6 +31,7 @@ from tubular.mixins import DropOriginalMixin, WeightColumnMixin
 from tubular.types import (
     DataFrame,
     FloatBetweenZeroOne,
+    LazyFrame,
     ListOfStrs,
     PositiveInt,
     Series,
@@ -1175,7 +1176,7 @@ class MeanResponseTransformer(
 
     @block_from_json
     @beartype
-    def fit(self, X: DataFrame, y: Series) -> MeanResponseTransformer:  # noqa:PLR0914, will simplify in future issue
+    def fit(self, X: DataFrame, y: Series | LazyFrame) -> MeanResponseTransformer:  # noqa:PLR0914, will simplify in future issue
         """Identify mapping of categorical levels to mean response values.
 
         If the user specified the weights_column arg in when initialising the transformer
@@ -1190,7 +1191,7 @@ class MeanResponseTransformer(
             Data to with catgeorical variable columns to transform and also containing response_column
             column.
 
-        y : Series
+        y : Series or LazyFrame
             Response variable or target.
 
         Returns
@@ -2174,7 +2175,7 @@ class OrdinalEncoderTransformer(
             raise ValueError(msg)
 
     @beartype
-    def fit(self, X: DataFrame, y: Series) -> OrdinalEncoderTransformer:
+    def fit(self, X: DataFrame, y: Series | LazyFrame) -> OrdinalEncoderTransformer:
         """Identify mapping of categorical levels to rank-ordered integer values by target-mean in ascending order.
 
         If the user specified the weights_column arg in when initialising the transformer
@@ -2186,7 +2187,7 @@ class OrdinalEncoderTransformer(
             Data to with catgeorical variable columns to transform and response_column column
             specified when object was initialised.
 
-        y : Series
+        y : Series or LazyFrame
             Response column or target.
 
         Returns

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -2175,7 +2175,7 @@ class OrdinalEncoderTransformer(
             raise ValueError(msg)
 
     @beartype
-    def fit(self, X: DataFrame, y: Series | LazyFrame) -> OrdinalEncoderTransformer:
+    def fit(self, X: DataFrame, y: Series) -> OrdinalEncoderTransformer:
         """Identify mapping of categorical levels to rank-ordered integer values by target-mean in ascending order.
 
         If the user specified the weights_column arg in when initialising the transformer

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -18,6 +18,7 @@ from tubular._stats import (
 )
 from tubular._utils import (
     _collect_frame,
+    _collect_series,
     _convert_dataframe_to_narwhals,
     _convert_series_to_narwhals,
     _is_null,
@@ -1224,6 +1225,9 @@ class MeanResponseTransformer(
 
         BaseNominalTransformer.fit(self, X, y)
 
+        # Collect lazy y to enable operations like .unique().to_list()
+        y = _collect_series(y)
+
         self.mappings = {}
         self.unseen_levels_encoding_dict = {}
 
@@ -2198,6 +2202,9 @@ class OrdinalEncoderTransformer(
         y = _convert_series_to_narwhals(y)
 
         BaseNominalTransformer.fit(self, X, y)
+
+        # Collect lazy y to enable operations like .is_null().sum()
+        y = _collect_series(y)
 
         self.mappings = {}
 

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -18,7 +18,6 @@ from tubular._stats import (
 )
 from tubular._utils import (
     _collect_frame,
-    _collect_series,
     _convert_dataframe_to_narwhals,
     _convert_series_to_narwhals,
     _is_null,
@@ -2200,9 +2199,6 @@ class OrdinalEncoderTransformer(
         y = _convert_series_to_narwhals(y)
 
         BaseNominalTransformer.fit(self, X, y)
-
-        # Collect lazy y to enable operations like .is_null().sum()
-        y = _collect_series(y)
 
         self.mappings = {}
 

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -1848,7 +1848,7 @@ class OneHotEncodingTransformer(
     def fit(
         self,
         X: DataFrame,
-        y: Series | None = None,
+        y: Series | LazyFrame | None = None,
     ) -> OneHotEncodingTransformer:
         """Get list of levels for each column to be transformed.
 

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -468,7 +468,7 @@ class GroupRareLevelsTransformer(BaseTransformer, WeightColumnMixin):
     def fit(
         self,
         X: DataFrame,
-        y: Series | None = None,
+        y: Series | LazyFrame | None = None,
     ) -> GroupRareLevelsTransformer:
         """Record non-rare levels for categorical variables.
 
@@ -483,7 +483,7 @@ class GroupRareLevelsTransformer(BaseTransformer, WeightColumnMixin):
         X : DataFrame
             Data to identify non-rare levels from.
 
-        y : Series or None, default = None
+        y : Series or LazyFrame or None, default = None
             Optional argument only required for the transformer to work with sklearn pipelines.
 
         Returns

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -1226,9 +1226,6 @@ class MeanResponseTransformer(
 
         BaseNominalTransformer.fit(self, X, y)
 
-        # Collect lazy y to enable operations like .unique().to_list()
-        y = _collect_series(y)
-
         self.mappings = {}
         self.unseen_levels_encoding_dict = {}
 

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -1176,7 +1176,7 @@ class MeanResponseTransformer(
 
     @block_from_json
     @beartype
-    def fit(self, X: DataFrame, y: Series | LazyFrame) -> MeanResponseTransformer:  # noqa:PLR0914, will simplify in future issue
+    def fit(self, X: DataFrame, y: Series) -> MeanResponseTransformer:  # noqa:PLR0914, will simplify in future issue
         """Identify mapping of categorical levels to mean response values.
 
         If the user specified the weights_column arg in when initialising the transformer

--- a/tubular/types.py
+++ b/tubular/types.py
@@ -12,7 +12,9 @@ DataFrame = pd.DataFrame | pl.DataFrame | pl.LazyFrame | nw.DataFrame | nw.LazyF
 
 NarwhalsFrame = nw.DataFrame | nw.LazyFrame
 
-Series = pd.Series | pl.Series | pl.LazyFrame | nw.Series | nw.LazyFrame
+Series = pd.Series | pl.Series | nw.Series
+
+LazyFrame = pl.LazyFrame | nw.LazyFrame
 
 NumericTypes = [
     nw.Int8,

--- a/tubular/types.py
+++ b/tubular/types.py
@@ -12,7 +12,7 @@ DataFrame = pd.DataFrame | pl.DataFrame | pl.LazyFrame | nw.DataFrame | nw.LazyF
 
 NarwhalsFrame = nw.DataFrame | nw.LazyFrame
 
-Series = pd.Series | pl.Series | nw.Series
+Series = pd.Series | pl.Series | pl.LazyFrame | nw.Series
 
 NumericTypes = [
     nw.Int8,

--- a/tubular/types.py
+++ b/tubular/types.py
@@ -12,7 +12,7 @@ DataFrame = pd.DataFrame | pl.DataFrame | pl.LazyFrame | nw.DataFrame | nw.LazyF
 
 NarwhalsFrame = nw.DataFrame | nw.LazyFrame
 
-Series = pd.Series | pl.Series | pl.LazyFrame | nw.Series
+Series = pd.Series | pl.Series | pl.LazyFrame | nw.Series | nw.LazyFrame
 
 NumericTypes = [
     nw.Int8,


### PR DESCRIPTION
This PR enables transformers to accept `pl.LazyFrame` for the target y  during `fit()`, minimising data collection and memory usage while maximizing lazy evaluation efficiency.

Changes:

- tubular/types.py: Updated Series type to include `pl.LazyFrame` and `nw.LazyFrame`
- tubular/_utils.py:
	- Updated `_convert_series_to_narwhals()` to handle `nw.LazyFrame` alongside `nw.Series`
	- Added `_collect_series()` helper to collect lazy frames only when computation is necessary
- tubular/imputers.py: Updated to use `_collect_series()` for lazy y collection
- tubular/nominal.py: Updated to use `_collect_series()` for lazy y collection
