### PR TITLE
added get_transform_exprs methods for easier classes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,7 @@ Changed
 - added LowerCaseTransformer and RemoveCharactersTransformer to string module
 - added functions module for stateless transforms
 - removed narwhals private import from nominal module `#725 <https://github.com/azukds/tubular/issues/725>_`
+- setup get_transform_exprs methods for aggregations/comparison/dates/misc/numeric, and OneHotEncoder/MeanResponseTransformer
 
 3.3.0 (30/04/2026)
 ------------------

--- a/tests/comparison/test_CompareTwoColumnsTransformer.py
+++ b/tests/comparison/test_CompareTwoColumnsTransformer.py
@@ -1,6 +1,5 @@
 import copy
 
-import narwhals as nw
 import pytest
 from beartype.roar import BeartypeCallHintParamViolation
 
@@ -12,7 +11,7 @@ from tests.base_tests import (
     OtherBaseBehaviourTests,
     OtherBaseBehaviourTestsNumeric,
 )
-from tubular.comparison import ConditionEnum
+from tubular.functions.comparison import ConditionEnum
 
 
 def create_compare_test_df(library="pandas"):
@@ -157,12 +156,6 @@ class TestCompareTwoColumnsTransformerTransform(GenericTransformTests):
         }
         expected_df = u.dataframe_init_dispatch(expected_data, library)
 
-        expected_df = nw.from_native(expected_df)
-
-        expected_df = expected_df.with_columns(
-            nw.maybe_convert_dtypes(expected_df[f"a{condition.value}b"]),
-        ).to_native()
-
         u.assert_frame_equal_dispatch(
             u._collect_frame(transformed_df, lazy),
             expected_df,
@@ -216,12 +209,6 @@ class TestCompareTwoColumnsTransformerTransform(GenericTransformTests):
             f"a{condition.value}b": expected_result,
         }
         expected_df = u.dataframe_init_dispatch(expected_data, library)
-
-        expected_df = nw.from_native(expected_df)
-
-        expected_df = expected_df.with_columns(
-            nw.maybe_convert_dtypes(expected_df[f"a{condition.value}b"]),
-        ).to_native()
 
         u.assert_frame_equal_dispatch(
             u._collect_frame(transformed_df, lazy),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ from tests.test_data import (
     create_when_then_otherwise_test_df,
 )
 from tubular import base
-from tubular.comparison import ConditionEnum
+from tubular.functions.comparison import ConditionEnum
 
 if TYPE_CHECKING:
     import pandas as pd

--- a/tests/dates/test_DateTimeInfoExtractor.py
+++ b/tests/dates/test_DateTimeInfoExtractor.py
@@ -24,7 +24,8 @@ from tests.utils import (
     assert_frame_equal_dispatch,
     dataframe_init_dispatch,
 )
-from tubular.dates import DatetimeInfoExtractor, DatetimeInfoOptions
+from tubular.dates import DatetimeInfoExtractor
+from tubular.functions.dates import DatetimeInfoOptions
 
 
 @pytest.fixture

--- a/tubular/aggregations.py
+++ b/tubular/aggregations.py
@@ -1,12 +1,10 @@
 """Contains transformers for performing data aggregations."""
 
-from enum import Enum
 from typing import Any
 
 import narwhals as nw
 from beartype import beartype
-from beartype.typing import Annotated, List, Optional
-from beartype.vale import Is
+from beartype.typing import Optional
 
 from tubular._utils import (
     _convert_dataframe_to_narwhals,
@@ -14,51 +12,14 @@ from tubular._utils import (
     block_from_json,
 )
 from tubular.base import BaseTransformer, register
+from tubular.functions.aggregations import (
+    ListOfColumnsOverRowAggregations,
+    ListOfRowsOverColumnsAggregations,
+    aggregate_over_columns,
+    aggregate_over_rows,
+)
 from tubular.mixins import DropOriginalMixin
 from tubular.types import DataFrame, ListOfStrs, NumericTypes
-
-
-class ColumnsOverRowAggregationOptions(str, Enum):
-    """Aggregation options for ColumnsOverRowAggregationTransformer."""
-
-    MIN = "min"
-    MAX = "max"
-    MEAN = "mean"
-    SUM = "sum"
-    # not currently easy to implement row-wise
-    # median or count, so leaving out for now
-
-
-class RowsOverColumnsAggregationOptions(str, Enum):
-    """Aggregation options for RowsOverColumnAggregationTransformer."""
-
-    MIN = "min"
-    MAX = "max"
-    MEAN = "mean"
-    SUM = "sum"
-    MEDIAN = "median"
-    COUNT = "count"
-
-
-ListOfColumnsOverRowAggregations = Annotated[
-    List,
-    Is[
-        lambda list_value: all(
-            entry in ColumnsOverRowAggregationOptions._value2member_map_
-            for entry in list_value
-        )
-    ],
-]
-
-ListOfRowsOverColumnsAggregations = Annotated[
-    List,
-    Is[
-        lambda list_value: all(
-            entry in RowsOverColumnsAggregationOptions._value2member_map_
-            for entry in list_value
-        )
-    ],
-]
 
 
 @register
@@ -426,6 +387,18 @@ class AggregateRowsOverColumnTransformer(BaseAggregationTransformer):
         """
         return [f"{col}_{agg}" for col in self.columns for agg in self.aggregations]
 
+    def get_transform_exprs(self) -> list[nw.Expr]:
+        """Get transform expressions.
+
+        Returns
+        -------
+        list[nw.Expr]: transform expressions for class
+
+        """
+        return aggregate_over_rows(
+            columns=self.columns, key=self.key, aggregations=self.aggregations
+        )
+
     @beartype
     def transform(
         self,
@@ -484,13 +457,9 @@ class AggregateRowsOverColumnTransformer(BaseAggregationTransformer):
             msg = f"{self.classname()}: key '{self.key}' not found in dataframe columns"
             raise ValueError(msg)
 
-        expr_dict = {
-            f"{col}_{agg}": getattr(nw.col(col), agg)().over(self.key)
-            for col in self.columns
-            for agg in self.aggregations
-        }
+        self.transform_exprs = self.get_transform_exprs()
 
-        X = X.with_columns(**expr_dict) if expr_dict else X
+        X = X.with_columns(*self.transform_exprs) if self.transform_exprs else X
 
         X = DropOriginalMixin.drop_original_column(
             X,
@@ -616,6 +585,18 @@ class AggregateColumnsOverRowTransformer(BaseAggregationTransformer):
         """
         return ["_".join(self.columns) + "_" + agg for agg in self.aggregations]
 
+    def get_transform_exprs(self) -> list[nw.Expr]:
+        """Get transform expressions.
+
+        Returns
+        -------
+        list[nw.Expr]: transform expressions for class
+
+        """
+        return aggregate_over_columns(
+            columns=self.columns, aggregations=self.aggregations
+        )
+
     @beartype
     def transform(
         self,
@@ -663,29 +644,9 @@ class AggregateColumnsOverRowTransformer(BaseAggregationTransformer):
 
         X = super().transform(X, return_native_override=False)
 
-        expr_map = (
-            {
-                "min": nw.min_horizontal(*self.columns),
-                "max": nw.max_horizontal(*self.columns),
-                "sum": nw.sum_horizontal(*self.columns),
-                "mean": nw.mean_horizontal(*self.columns),
-            }
-            if self.columns
-            else {}
-        )
+        transform_exprs = self.get_transform_exprs()
 
-        transform_dict = (
-            {
-                "_".join(self.columns) + "_" + aggregation: expr_map[aggregation].alias(
-                    "_".join(self.columns) + "_" + aggregation,
-                )
-                for aggregation in self.aggregations
-            }
-            if expr_map
-            else {}
-        )
-
-        X = X.with_columns(**transform_dict) if transform_dict else X
+        X = X.with_columns(*transform_exprs) if transform_exprs else X
 
         X = DropOriginalMixin.drop_original_column(
             X,

--- a/tubular/comparison.py
+++ b/tubular/comparison.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import operator
-from enum import Enum
-from typing import TYPE_CHECKING, Annotated, Any, ClassVar
+from typing import TYPE_CHECKING, Any
 
 import narwhals as nw
 
@@ -19,29 +17,18 @@ from tubular._utils import (
     block_from_json,
 )
 from tubular.base import BaseTransformer
+from tubular.functions.comparison import (
+    ConditionEnumStr,
+    apply_when_then_otherwise,
+    compare_two_columns,
+)
 from tubular.mixins import DropOriginalMixin
 from tubular.types import (
     DataFrame,
-    Is,
     ListOfStrs,
     ListOfTwoStrs,
     NumericTypes,
 )
-
-
-class ConditionEnum(Enum):
-    """Enumeration of comparison conditions."""
-
-    GREATER_THAN = ">"
-    LESS_THAN = "<"
-    EQUAL_TO = "=="
-    NOT_EQUAL_TO = "!="
-
-
-ConditionEnumStr = Annotated[
-    str,
-    Is[lambda s: s in ConditionEnum._value2member_map_],
-]
 
 
 class WhenThenOtherwiseTransformer(BaseTransformer):
@@ -177,6 +164,20 @@ class WhenThenOtherwiseTransformer(BaseTransformer):
 
         return json_dict
 
+    def get_transform_exprs(self) -> list[nw.Expr]:
+        """Get transform expressions.
+
+        Returns
+        -------
+        list[nw.Expr]: transform expressions for class
+
+        """
+        return apply_when_then_otherwise(
+            columns=self.columns,
+            when_column=self.when_column,
+            then_column=self.then_column,
+        )
+
     @beartype
     def transform(
         self,
@@ -249,14 +250,9 @@ class WhenThenOtherwiseTransformer(BaseTransformer):
             )
             raise TypeError(message)
 
-        exprs_dict = {
-            col: nw.when(nw.col(self.when_column))
-            .then(nw.col(self.then_column))
-            .otherwise(nw.col(col))
-            for col in self.columns
-        }
+        transform_exprs = self.get_transform_exprs()
 
-        X = X.with_columns(**exprs_dict) if exprs_dict else X
+        X = X.with_columns(*transform_exprs) if transform_exprs else X
 
         return _return_narwhals_or_native_dataframe(X, self.return_native)
 
@@ -313,14 +309,6 @@ class CompareTwoColumnsTransformer(BaseTransformer):
     jsonable = True
     lazyframe_compatible = True
 
-    # Map the enum to the operator functions
-    ops_map: ClassVar[dict[ConditionEnum, Any]] = {
-        ConditionEnum.GREATER_THAN: operator.gt,
-        ConditionEnum.LESS_THAN: operator.lt,
-        ConditionEnum.EQUAL_TO: operator.eq,
-        ConditionEnum.NOT_EQUAL_TO: operator.ne,
-    }
-
     @beartype
     def __init__(
         self,
@@ -357,6 +345,7 @@ class CompareTwoColumnsTransformer(BaseTransformer):
         Examples
         --------
         ```pycon
+        >>> from tubular.functions.comparison import ConditionEnum
         >>> transformer = CompareTwoColumnsTransformer(
         ...     columns=["a", "b"],
         ...     condition=ConditionEnum.GREATER_THAN.value,
@@ -381,6 +370,19 @@ class CompareTwoColumnsTransformer(BaseTransformer):
         json_dict["init"]["condition"] = self.condition
 
         return json_dict
+
+    def get_transform_exprs(self) -> list[nw.Expr]:
+        """Get transform expressions.
+
+        Returns
+        -------
+        list[nw.Expr]: transform expressions for class
+
+        """
+        return compare_two_columns(
+            columns=self.columns,
+            condition=self.condition,
+        )
 
     @beartype
     def transform(self, X: DataFrame) -> DataFrame:
@@ -439,33 +441,9 @@ class CompareTwoColumnsTransformer(BaseTransformer):
             )
             raise TypeError(message)
 
-        null_filter_expr = (
-            nw.col(self.columns[0]).is_null() | nw.col(self.columns[1]).is_null()
-        )
+        transform_expr = self.get_transform_exprs()
 
-        expr = (
-            nw.when(~null_filter_expr)
-            .then(
-                self.ops_map[ConditionEnum(self.condition)](
-                    nw.col(self.columns[0]), nw.col(self.columns[1])
-                )
-            )
-            .otherwise(None)
-        )
-
-        backend = nw.get_native_namespace(X).__name__
-
-        if backend == "polars":
-            expr = expr.cast(nw.Boolean)
-
-        outcome_column_name = f"{self.columns[0]}{self.condition}{self.columns[1]}"
-
-        X = X.with_columns(expr.alias(outcome_column_name))
-
-        if backend == "pandas":
-            X = X.with_columns(
-                nw.maybe_convert_dtypes(X[outcome_column_name]).cast(nw.Boolean)
-            )
+        X = X.with_columns(transform_expr)
 
         return _return_narwhals_or_native_dataframe(X, self.return_native)
 

--- a/tubular/dates.py
+++ b/tubular/dates.py
@@ -2,17 +2,14 @@
 
 from __future__ import annotations
 
-import copy
 import datetime
 import warnings
-from enum import Enum
-from typing import TYPE_CHECKING, Annotated, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import narwhals as nw
 import numpy as np
 import pandas as pd
 from beartype import beartype
-from beartype.vale import Is
 from typing_extensions import deprecated
 
 from tubular._utils import (
@@ -21,6 +18,25 @@ from tubular._utils import (
     block_from_json,
 )
 from tubular.base import BaseTransformer, register
+from tubular.functions.dates import (
+    INCLUDE_OPTIONS,
+    RANGE_TO_MAP,
+    DateDifferenceUnitsOptionsStr,
+    DatetimeComponentOptionList,
+    DatetimeComponentOptionStr,
+    DatetimeInfoOptionList,
+    DatetimeInfoOptionStr,
+    DatetimeSinusoidUnitsOptionStr,
+    MethodOptionList,
+    MethodOptionStr,
+    NumberNotBool,
+    check_if_three_date_columns_are_sequential,
+    convert_columns_to_datetime,
+    diff_two_dates,
+    extract_datetime_components,
+    extract_datetime_info,
+    extract_datetime_sinusoid_components,
+)
 from tubular.mixins import DropOriginalMixin
 from tubular.types import (
     DataFrame,
@@ -493,28 +509,6 @@ class BaseDatetimeTransformer(BaseGenericDateTransformer):
         return _return_narwhals_or_native_dataframe(X, return_native)
 
 
-class DateDifferenceUnitsOptions(str, Enum):
-    """Options for return units in DateDifferenceTransformer."""
-
-    __slots__ = ()
-
-    WEEK = "week"
-    FORTNIGHT = "fortnight"
-    LUNAR_MONTH = "lunar_month"
-    COMMON_YEAR = "common_year"
-    CUSTOM_DAYS = "custom_days"
-    DAYS = "D"
-    HOURS = "h"
-    MINUTES = "m"
-    SECONDS = "s"
-
-
-DateDifferenceUnitsOptionsStr = Annotated[
-    str,
-    Is[lambda s: s in DateDifferenceUnitsOptions._value2member_map_],
-]
-
-
 @register
 class DateDifferenceTransformer(BaseGenericDateTransformer):
     """Class to transform calculate the difference between 2 date fields in specified units.
@@ -655,6 +649,21 @@ class DateDifferenceTransformer(BaseGenericDateTransformer):
 
         return json_dict
 
+    def get_transform_exprs(self) -> list[nw.Expr]:
+        """Get transform expressions.
+
+        Returns
+        -------
+        list[nw.Expr]: transform expressions for class
+
+        """
+        return diff_two_dates(
+            columns=self.columns,
+            units=self.units,
+            new_column_name=self.new_column_name,
+            custom_days_divider=self.custom_days_divider,
+        )
+
     @beartype
     def transform(self, X: DataFrame) -> DataFrame:
         """Calculate the difference between the given fields in the specified units.
@@ -706,48 +715,10 @@ class DateDifferenceTransformer(BaseGenericDateTransformer):
 
         X = super().transform(X, return_native_override=False)
 
-        # mapping for units and corresponding timedelta arg values
-        UNITS_TO_TIMEDELTA_PARAMS = {
-            "week": (7, "D"),
-            "fortnight": (14, "D"),
-            "lunar_month": (
-                int(29.5 * 24),
-                "h",
-            ),  # timedelta values need to be whole numbers so (29.5, 'D') cannot be used
-            "common_year": (365, "D"),
-            "D": (1, "D"),
-            "h": (1, "h"),
-            "m": (1, "m"),
-            "s": (1, "s"),
-        }
-
-        # list of units that require time truncation
-        UNITS_TO_TRUNCATE_TIME_FOR = [
-            "week",
-            "fortnight",
-            "lunar_month",
-            "common_year",
-            "custom_days",
-            "D",
-        ]
-
-        start_date_col = nw.col(self.columns[0])
-        end_date_col = nw.col(self.columns[1])
-
-        # truncating time for specific units
-        if self.units in UNITS_TO_TRUNCATE_TIME_FOR:
-            start_date_col = start_date_col.dt.truncate("1d")
-            end_date_col = end_date_col.dt.truncate("1d")
-
-        if self.units == "custom_days":
-            timedelta_value, timedelta_format = self.custom_days_divider, "D"
-            denominator = np.timedelta64(timedelta_value, timedelta_format)
-        else:
-            timedelta_value, timedelta_format = UNITS_TO_TIMEDELTA_PARAMS[self.units]
-            denominator = np.timedelta64(timedelta_value, timedelta_format)
+        transform_expr = self.get_transform_exprs()
 
         X = X.with_columns(
-            ((end_date_col - start_date_col) / denominator).alias(self.new_column_name),
+            transform_expr,
         )
 
         # Drop original columns if self.drop_original is True
@@ -877,6 +848,18 @@ class ToDatetimeTransformer(BaseTransformer):
         )
         return json_dict
 
+    def get_transform_exprs(self) -> list[nw.Expr]:
+        """Get transform expressions.
+
+        Returns
+        -------
+        list[nw.Expr]: transform expressions for class
+
+        """
+        return convert_columns_to_datetime(
+            columns=self.columns, time_format=self.time_format
+        )
+
     @beartype
     def transform(self, X: DataFrame) -> DataFrame:
         """Convert specified column to datetime using pd.to_datetime.
@@ -921,9 +904,9 @@ class ToDatetimeTransformer(BaseTransformer):
 
         X = super().transform(X, return_native_override=False)
 
-        X = X.with_columns(
-            nw.col(col).str.to_datetime(format=self.time_format) for col in self.columns
-        )
+        transform_exprs = self.get_transform_exprs()
+
+        X = X.with_columns(*transform_exprs)
 
         return _return_narwhals_or_native_dataframe(X, return_native=self.return_native)
 
@@ -1093,6 +1076,21 @@ class BetweenDatesTransformer(BaseGenericDateTransformer):
 
         return json_dict
 
+    def get_transform_exprs(self) -> list[nw.Expr]:
+        """Get transform expressions.
+
+        Returns
+        -------
+        list[nw.Expr]: transform expressions for class
+
+        """
+        return check_if_three_date_columns_are_sequential(
+            columns=self.columns,
+            lower_inclusive=self.lower_inclusive,
+            upper_inclusive=self.upper_inclusive,
+            new_column_name=self.new_column_name,
+        )
+
     @nw.narwhalify
     def transform(self, X: FrameT) -> FrameT:
         """Transform - creates column indicating if middle date is between the other two.
@@ -1161,25 +1159,9 @@ class BetweenDatesTransformer(BaseGenericDateTransformer):
         """
         X = nw.from_native(super().transform(X))
 
-        lower_comparison = (
-            nw.col(self.columns[0]) <= nw.col(self.columns[1])
-            if self.lower_inclusive
-            else nw.col(self.columns[0]) < nw.col(self.columns[1])
-        )
+        transform_expr = self.get_transform_exprs()
 
-        upper_comparison = (
-            nw.col(self.columns[1]) <= nw.col(self.columns[2])
-            if self.upper_inclusive
-            else nw.col(self.columns[1]) < nw.col(self.columns[2])
-        )
-
-        X = X.with_columns(
-            nw.when(nw.col(self.columns[0]) > nw.col(self.columns[2]))
-            .then(None)
-            .otherwise(lower_comparison & upper_comparison)
-            .cast(nw.Boolean)
-            .alias(self.new_column_name),
-        )
+        X = X.with_columns(transform_expr)
 
         # Drop original columns if self.drop_original is True
         return DropOriginalMixin.drop_original_column(
@@ -1187,31 +1169,6 @@ class BetweenDatesTransformer(BaseGenericDateTransformer):
             self.drop_original,
             self.columns,
         )
-
-
-class DatetimeInfoOptions(str, Enum):
-    """Options for what is returned by DatetimeInfoExtractor."""
-
-    __slots__ = ()
-
-    TIME_OF_DAY = "timeofday"
-    TIME_OF_MONTH = "timeofmonth"
-    TIME_OF_YEAR = "timeofyear"
-    DAY_OF_WEEK = "dayofweek"
-
-
-DatetimeInfoOptionStr = Annotated[
-    str,
-    Is[lambda s: s in DatetimeInfoOptions._value2member_map_],
-]
-DatetimeInfoOptionList = Annotated[
-    list,
-    Is[
-        lambda list_value: all(
-            entry in DatetimeInfoOptions._value2member_map_ for entry in list_value
-        )
-    ],
-]
 
 
 @register
@@ -1274,50 +1231,8 @@ class DatetimeInfoExtractor(BaseDatetimeTransformer):
 
     jsonable = True
 
-    DEFAULT_MAPPINGS: ClassVar[dict[str, dict[int, str]]] = {
-        DatetimeInfoOptions.TIME_OF_DAY.value: {
-            **dict.fromkeys(range(6), "night"),  # Midnight - 6am
-            **dict.fromkeys(range(6, 12), "morning"),  # 6am - Noon
-            **dict.fromkeys(range(12, 18), "afternoon"),  # Noon - 6pm
-            **dict.fromkeys(range(18, 24), "evening"),  # 6pm - Midnight
-        },
-        DatetimeInfoOptions.TIME_OF_MONTH.value: {
-            **dict.fromkeys(range(1, 11), "start"),
-            **dict.fromkeys(range(11, 21), "middle"),
-            **dict.fromkeys(range(21, 32), "end"),
-        },
-        DatetimeInfoOptions.TIME_OF_YEAR.value: {
-            **dict.fromkeys(range(3, 6), "spring"),  # Mar, Apr, May
-            **dict.fromkeys(range(6, 9), "summer"),  # Jun, Jul, Aug
-            **dict.fromkeys(range(9, 12), "autumn"),  # Sep, Oct, Nov
-            **dict.fromkeys([12, 1, 2], "winter"),  # Dec, Jan, Feb
-        },
-        DatetimeInfoOptions.DAY_OF_WEEK.value: {
-            1: "monday",
-            2: "tuesday",
-            3: "wednesday",
-            4: "thursday",
-            5: "friday",
-            6: "saturday",
-            7: "sunday",
-        },
-    }
-
-    INCLUDE_OPTIONS: ClassVar[list[str]] = list(DEFAULT_MAPPINGS.keys())
-
-    RANGE_TO_MAP: ClassVar[dict[str, set[int]]] = {
-        DatetimeInfoOptions.TIME_OF_DAY.value: set(range(24)),
-        DatetimeInfoOptions.TIME_OF_MONTH.value: set(range(1, 32)),
-        DatetimeInfoOptions.TIME_OF_YEAR.value: set(range(1, 13)),
-        DatetimeInfoOptions.DAY_OF_WEEK.value: set(range(1, 8)),
-    }
-
-    DATETIME_ATTR: ClassVar[dict[str, str]] = {
-        DatetimeInfoOptions.TIME_OF_DAY.value: "hour",
-        DatetimeInfoOptions.TIME_OF_MONTH.value: "day",
-        DatetimeInfoOptions.TIME_OF_YEAR.value: "month",
-        DatetimeInfoOptions.DAY_OF_WEEK.value: "weekday",
-    }
+    INCLUDE_OPTIONS = INCLUDE_OPTIONS
+    RANGE_TO_MAP = RANGE_TO_MAP
 
     @beartype
     def __init__(
@@ -1357,7 +1272,7 @@ class DatetimeInfoExtractor(BaseDatetimeTransformer):
                 dayofweek: 1-7
 
             If an option is present in 'include' but no mappings are provided,
-            then default values from cls.DEFAULT_MAPPINGS will be used for this
+            then default values from DEFAULT_MAPPINGS will be used for this
             option.
 
         drop_original: str
@@ -1498,6 +1413,20 @@ class DatetimeInfoExtractor(BaseDatetimeTransformer):
                     msg = f"{self.classname()}: {key} mapping dictionary should contain mapping for all values between {min(self.RANGE_TO_MAP[key])}-{max(self.RANGE_TO_MAP[key])}. {self.RANGE_TO_MAP[key] - set(datetime_mappings[key].keys())} are missing"
                     raise ValueError(msg)
 
+    def get_transform_exprs(self) -> list[nw.Expr]:
+        """Get transform expressions.
+
+        Returns
+        -------
+        list[nw.Expr]: transform expressions for class
+
+        """
+        return extract_datetime_info(
+            columns=self.columns,
+            datetime_mappings=self.datetime_mappings,
+            include=self.include,
+        )
+
     @beartype
     def transform(self, X: DataFrame) -> DataFrame:
         """Transform - Extracts new features from datetime variables.
@@ -1546,58 +1475,13 @@ class DatetimeInfoExtractor(BaseDatetimeTransformer):
         """
         X = super().transform(X, return_native_override=False)
 
-        # initialise mappings attr with defaults,
-        # and overwrite with user provided mappings
-        # where possible
-        final_datetime_mappings = copy.deepcopy(self.DEFAULT_MAPPINGS)
-        for key in self.datetime_mappings:
-            final_datetime_mappings[key] = copy.deepcopy(
-                self.datetime_mappings[key],
-            )
-
-        # this is a situation where we know the values our mappings allow,
-        # so enum type is more appropriate than categorical and we
-        # will cast to this at the end
-        enums = {
-            include_option: nw.Enum(
-                sorted(set(final_datetime_mappings[include_option].values())),
-            )
-            for include_option in self.include
-        }
-
-        mappings_dict = {
-            col + "_" + include_option: final_datetime_mappings[include_option]
-            for col in self.columns
-            for include_option in self.include
-        }
-
-        transform_dict = {
-            col + "_" + include_option: (
-                getattr(
-                    nw.col(col).dt,
-                    self.DATETIME_ATTR[include_option],
-                )().replace_strict(
-                    mappings_dict[col + "_" + include_option],
-                )
-            )
-            for col in self.columns
-            for include_option in self.include
-        }
-
-        # final casts
-        transform_dict = {
-            col + "_" + include_option: transform_dict[col + "_" + include_option].cast(
-                enums[include_option],
-            )
-            for col in self.columns
-            for include_option in self.include
-        }
+        transform_exprs = self.get_transform_exprs()
 
         X = (
             X.with_columns(
-                **transform_dict,
+                *transform_exprs,
             )
-            if transform_dict
+            if transform_exprs
             else X
         )
 
@@ -1610,31 +1494,6 @@ class DatetimeInfoExtractor(BaseDatetimeTransformer):
         )
 
         return _return_narwhals_or_native_dataframe(X, self.return_native)
-
-
-class DatetimeComponentOptions(str, Enum):
-    """Contains options for DatetimeComponentExtractor."""
-
-    __slots__ = ()
-
-    HOUR = "hour"
-    DAY = "day"
-    MONTH = "month"
-    YEAR = "year"
-
-
-DatetimeComponentOptionStr = Annotated[
-    str,
-    Is[lambda s: s in DatetimeComponentOptions._value2member_map_],
-]
-DatetimeComponentOptionList = Annotated[
-    list,
-    Is[
-        lambda list_value: all(
-            entry in DatetimeComponentOptions._value2member_map_ for entry in list_value
-        )
-    ],
-]
 
 
 class DatetimeComponentExtractor(BaseDatetimeTransformer):
@@ -1790,6 +1649,16 @@ class DatetimeComponentExtractor(BaseDatetimeTransformer):
         json_dict["init"]["include"] = self.include
         return json_dict
 
+    def get_transform_exprs(self) -> list[nw.Expr]:
+        """Get transform expressions.
+
+        Returns
+        -------
+        list[nw.Expr]: transform expressions for class
+
+        """
+        return extract_datetime_components(columns=self.columns, include=self.include)
+
     @beartype
     def transform(self, X: DataFrame) -> DataFrame:
         """Transform - Extracts numeric datetime components.
@@ -1845,78 +1714,17 @@ class DatetimeComponentExtractor(BaseDatetimeTransformer):
         """
         X = super().transform(X, return_native_override=False)
 
-        transform_dict = {
-            col + "_" + include_option: (
-                getattr(
-                    nw.col(col).dt,
-                    include_option,
-                )().cast(nw.Float32)  # can't cast to int as may have nulls
-            )
-            for col in self.columns
-            for include_option in self.include
-        }
+        transform_exprs = self.get_transform_exprs()
 
         X = (
             X.with_columns(
-                **transform_dict,
+                *transform_exprs,
             )
-            if transform_dict
+            if transform_exprs
             else X
         )
 
         return _return_narwhals_or_native_dataframe(X, self.return_native)
-
-
-class DatetimeSinusoidUnitsOptions(str, Enum):
-    """Options for units argument of DatetimeSinusoidCalculator."""
-
-    __slots__ = ()
-
-    YEAR = "year"
-    MONTH = "month"
-    DAY = "day"
-    HOUR = "hour"
-    MINUTE = "minute"
-    SECOND = "second"
-    MICROSECOND = "microsecond"
-
-
-DatetimeSinusoidUnitsOptionStr = Annotated[
-    str,
-    Is[lambda s: s in DatetimeSinusoidUnitsOptions._value2member_map_],
-]
-
-
-class MethodOptions(str, Enum):
-    """Options for method arg of DatetimeSinusoidCalculator."""
-
-    __slots__ = ()
-
-    SIN = "sin"
-    COS = "cos"
-
-
-MethodOptionStr = Annotated[
-    str,
-    Is[lambda s: s in MethodOptions._value2member_map_],
-]
-
-MethodOptionList = Annotated[
-    list,
-    Is[
-        lambda list_value: all(
-            entry in MethodOptions._value2member_map_ for entry in list_value
-        )
-    ],
-]
-
-NumberNotBool = Annotated[
-    int | float,
-    Is[
-        # exclude bools which would pass isinstance(..., (float, int))
-        lambda value: type(value) in {int, float}
-    ],
-]
 
 
 @register
@@ -2129,6 +1937,21 @@ class DatetimeSinusoidCalculator(BaseDatetimeTransformer):
 
         return json_dict
 
+    def get_transform_exprs(self) -> list[nw.Expr]:
+        """Get transform expressions.
+
+        Returns
+        -------
+        list[nw.Expr]: transform expressions for class
+
+        """
+        return extract_datetime_sinusoid_components(
+            columns=self.columns,
+            period_dict=self.period_dict,
+            units_dict=self.units_dict,
+            method=self.method,
+        )
+
     @beartype
     def transform(
         self,
@@ -2191,28 +2014,10 @@ class DatetimeSinusoidCalculator(BaseDatetimeTransformer):
 
         X = super().transform(X, return_native_override=False)
 
-        # first convert to desired units
-        exprs = {
-            f"{method}_{self.period_dict[column]}_{self.units_dict[column]}_{column}": getattr(
-                nw.col(column).dt,
-                self.units_dict[column],
-            )()
-            * (2 * np.pi / self.period_dict[column])
-            for column in self.columns
-            for method in self.method
-        }
+        transform_exprs = self.get_transform_exprs()
 
-        # then take sin/cos
-        exprs = {
-            (
-                new_col_name
-                := f"{method}_{self.period_dict[column]}_{self.units_dict[column]}_{column}"
-            ): getattr(exprs[new_col_name], method)()
-            for column in self.columns
-            for method in self.method
-        }
+        X = X.with_columns(*transform_exprs) if transform_exprs else X
 
-        X = X.with_columns(**exprs) if exprs else X
         # Drop original columns if self.drop_original is True
         X = DropOriginalMixin.drop_original_column(
             X,

--- a/tubular/functions/aggregations.py
+++ b/tubular/functions/aggregations.py
@@ -1,0 +1,96 @@
+"""Contains stateless transforms for data aggregations."""
+
+from enum import Enum
+
+import narwhals as nw
+from beartype.typing import Annotated, List
+from beartype.vale import Is
+
+
+class ColumnsOverRowAggregationOptions(str, Enum):
+    """Aggregation options for ColumnsOverRowAggregationTransformer."""
+
+    MIN = "min"
+    MAX = "max"
+    MEAN = "mean"
+    SUM = "sum"
+    # not currently easy to implement row-wise
+    # median or count, so leaving out for now
+
+
+class RowsOverColumnsAggregationOptions(str, Enum):
+    """Aggregation options for RowsOverColumnAggregationTransformer."""
+
+    MIN = "min"
+    MAX = "max"
+    MEAN = "mean"
+    SUM = "sum"
+    MEDIAN = "median"
+    COUNT = "count"
+
+
+ListOfColumnsOverRowAggregations = Annotated[
+    List,
+    Is[
+        lambda list_value: all(
+            entry in ColumnsOverRowAggregationOptions._value2member_map_
+            for entry in list_value
+        )
+    ],
+]
+
+ListOfRowsOverColumnsAggregations = Annotated[
+    List,
+    Is[
+        lambda list_value: all(
+            entry in RowsOverColumnsAggregationOptions._value2member_map_
+            for entry in list_value
+        )
+    ],
+]
+
+horizontal_expr_map = {
+    "min": nw.min_horizontal,
+    "max": nw.max_horizontal,
+    "sum": nw.sum_horizontal,
+    "mean": nw.mean_horizontal,
+}
+
+
+def aggregate_over_rows(
+    columns: list[str], key: str, aggregations: ListOfRowsOverColumnsAggregations
+) -> nw.Expr:
+    """Get expressions for aggregating data over rows, grouping by a key.
+
+    Returns
+    -------
+    list[nw.Expr]: expressions for transformation
+
+    """
+    return [
+        getattr(nw.col(col), agg)().over(key).alias(f"{col}_{agg}")
+        for col in columns
+        for agg in aggregations
+    ]
+
+
+def aggregate_over_columns(
+    columns: list[str], aggregations: ListOfColumnsOverRowAggregations
+) -> nw.Expr:
+    """Get expressions for aggregating data over columns.
+
+    Returns
+    -------
+    list[nw.Expr]: expressions for transformation
+
+    """
+    return (
+        [
+            horizontal_expr_map[aggregation](columns).alias(
+                "_".join(columns) + "_" + aggregation,
+            )
+            for aggregation in aggregations
+        ]
+        if columns
+        else []
+    )

--- a/tubular/functions/comparison.py
+++ b/tubular/functions/comparison.py
@@ -1,0 +1,94 @@
+"""Contains stateless transforms for comparing columns."""
+
+import operator
+from enum import Enum
+from typing import Annotated
+
+import narwhals as nw
+from beartype.vale import Is
+
+from tubular.types import ListOfTwoStrs
+
+
+def apply_when_then_otherwise(
+    columns: list[str],
+    when_column: str,
+    then_column: str,
+) -> nw.Expr:
+    """Get expression for capping columns within provided ranges.
+
+    Parameters
+    ----------
+    columns:
+        columns to cap
+
+    when_column:
+        name of boolean mask column
+
+    then_column:
+        name of column provididing values for if 'when' condition is met
+
+    Returns
+    -------
+    list[nw.Expr]: expressions for transformation
+
+    """
+    return [
+        nw.when(nw.col(when_column))
+        .then(nw.col(then_column))
+        .otherwise(nw.col(col))
+        .alias(col)
+        for col in columns
+    ]
+
+
+class ConditionEnum(Enum):
+    """Enumeration of comparison conditions."""
+
+    GREATER_THAN = ">"
+    LESS_THAN = "<"
+    EQUAL_TO = "=="
+    NOT_EQUAL_TO = "!="
+
+
+ConditionEnumStr = Annotated[
+    str,
+    Is[lambda s: s in ConditionEnum._value2member_map_],
+]
+
+# Map the enum to the operator functions
+ops_map = {
+    ConditionEnum.GREATER_THAN: operator.gt,
+    ConditionEnum.LESS_THAN: operator.lt,
+    ConditionEnum.EQUAL_TO: operator.eq,
+    ConditionEnum.NOT_EQUAL_TO: operator.ne,
+}
+
+
+def compare_two_columns(
+    columns: ListOfTwoStrs,
+    condition: ConditionEnumStr,
+) -> nw.Expr:
+    """Get expression for capping columns within provided ranges.
+
+    Parameters
+    ----------
+    columns:
+        columns to cap
+
+    condition:
+        comparison condition, e.g. "<"
+
+    Returns
+    -------
+    list[nw.Expr]: expressions for transformation
+
+    """
+    null_filter_expr = nw.col(columns[0]).is_null() | nw.col(columns[1]).is_null()
+
+    return (
+        nw.when(~null_filter_expr)
+        .then(ops_map[ConditionEnum(condition)](nw.col(columns[0]), nw.col(columns[1])))
+        .otherwise(None)
+        .alias(f"{columns[0]}{condition}{columns[1]}")
+    )

--- a/tubular/functions/dates.py
+++ b/tubular/functions/dates.py
@@ -1,0 +1,499 @@
+"""Stateless transforms for date columns."""
+
+import copy
+from enum import Enum
+from typing import Annotated
+
+import narwhals as nw
+import numpy as np
+from beartype import beartype
+from beartype.vale import Is
+
+from tubular.types import ListOfThreeStrs, ListOfTwoStrs
+
+# mapping for units and corresponding timedelta arg values
+UNITS_TO_TIMEDELTA_PARAMS = {
+    "week": (7, "D"),
+    "fortnight": (14, "D"),
+    "lunar_month": (
+        int(29.5 * 24),
+        "h",
+    ),  # timedelta values need to be whole numbers so (29.5, 'D') cannot be used
+    "common_year": (365, "D"),
+    "D": (1, "D"),
+    "h": (1, "h"),
+    "m": (1, "m"),
+    "s": (1, "s"),
+}
+
+# list of units that require time truncation
+UNITS_TO_TRUNCATE_TIME_FOR = [
+    "week",
+    "fortnight",
+    "lunar_month",
+    "common_year",
+    "custom_days",
+    "D",
+]
+
+
+class DateDifferenceUnitsOptions(str, Enum):
+    """Options for return units in DateDifferenceTransformer."""
+
+    __slots__ = ()
+
+    WEEK = "week"
+    FORTNIGHT = "fortnight"
+    LUNAR_MONTH = "lunar_month"
+    COMMON_YEAR = "common_year"
+    CUSTOM_DAYS = "custom_days"
+    DAYS = "D"
+    HOURS = "h"
+    MINUTES = "m"
+    SECONDS = "s"
+
+
+DateDifferenceUnitsOptionsStr = Annotated[
+    str,
+    Is[lambda s: s in DateDifferenceUnitsOptions._value2member_map_],
+]
+
+
+@beartype
+def diff_two_dates(
+    columns: ListOfTwoStrs,
+    units: DateDifferenceUnitsOptionsStr,
+    new_column_name: str,
+    custom_days_divider: int | None = None,
+) -> nw.Expr:
+    """Get expression for calculating difference between provided dates.
+
+    Parameters
+    ----------
+    columns:
+        columns to difference, will calculate columns[1]-columns[0]
+    units:
+            Accepted values are "week", "fortnight", "lunar_month", "common_year", "custom_days", 'D', 'h', 'm', 's'
+    custom_days_divider:
+        Integer value for the "custom_days" unit
+    new_column_name:
+        name for output column
+
+    Returns
+    -------
+    list[nw.Expr]: expressions for transformation
+
+    """
+    start_date_col = nw.col(columns[0])
+    end_date_col = nw.col(columns[1])
+
+    # truncating time for specific units
+    if units in UNITS_TO_TRUNCATE_TIME_FOR:
+        start_date_col = start_date_col.dt.truncate("1d")
+        end_date_col = end_date_col.dt.truncate("1d")
+
+    if units == "custom_days":
+        timedelta_value, timedelta_format = custom_days_divider, "D"
+        denominator = np.timedelta64(timedelta_value, timedelta_format)
+    else:
+        timedelta_value, timedelta_format = UNITS_TO_TIMEDELTA_PARAMS[units]
+        denominator = np.timedelta64(timedelta_value, timedelta_format)
+
+    return ((end_date_col - start_date_col) / denominator).alias(new_column_name)
+
+
+@beartype
+def convert_columns_to_datetime(
+    columns: list[str], time_format: str | None = None
+) -> list[nw.Expr]:
+    """Get expression for calculating difference between provided dates.
+
+    Parameters
+    ----------
+    columns:
+        List of names of the column to convert to datetime.
+
+    time_format:
+        str indicating format of time to parse, e.g. '%d/%m/%Y'
+
+    Returns
+    -------
+    list[nw.Expr]: expressions for transformation
+
+    """
+    return [nw.col(col).str.to_datetime(format=time_format) for col in columns]
+
+
+@beartype
+def check_if_three_date_columns_are_sequential(
+    columns: ListOfThreeStrs,
+    lower_inclusive: bool,
+    upper_inclusive: bool,
+    new_column_name: str,
+) -> nw.Expr:
+    """Get expression for checking if three date columns are sequential.
+
+    Parameters
+    ----------
+    columns:
+        List of names of the column to convert to datetime.
+
+    lower_inclusive:
+        If lower_inclusive is True the comparison to column_lower will be column_lower <=
+        column_between, otherwise the comparison will be column_lower < column_between.
+
+    upper_inclusive:
+        If upper_inclusive is True the comparison to column_upper will be column_between <=
+        column_upper, otherwise the comparison will be column_between < column_upper.
+
+    new_column_name:
+        name for output column.
+
+    Returns
+    -------
+    list[nw.Expr]: expressions for transformation
+
+    """
+    lower_comparison = (
+        nw.col(columns[0]) <= nw.col(columns[1])
+        if lower_inclusive
+        else nw.col(columns[0]) < nw.col(columns[1])
+    )
+
+    upper_comparison = (
+        nw.col(columns[1]) <= nw.col(columns[2])
+        if upper_inclusive
+        else nw.col(columns[1]) < nw.col(columns[2])
+    )
+
+    return (
+        nw.when(nw.col(columns[0]) <= nw.col(columns[2]))
+        .then(lower_comparison & upper_comparison)
+        .otherwise(None)
+        .alias(new_column_name)
+    )
+
+
+class DatetimeInfoOptions(str, Enum):
+    """Options for what is returned by DatetimeInfoExtractor."""
+
+    __slots__ = ()
+
+    TIME_OF_DAY = "timeofday"
+    TIME_OF_MONTH = "timeofmonth"
+    TIME_OF_YEAR = "timeofyear"
+    DAY_OF_WEEK = "dayofweek"
+
+
+DatetimeInfoOptionStr = Annotated[
+    str,
+    Is[lambda s: s in DatetimeInfoOptions._value2member_map_],
+]
+DatetimeInfoOptionList = Annotated[
+    list,
+    Is[
+        lambda list_value: all(
+            entry in DatetimeInfoOptions._value2member_map_ for entry in list_value
+        )
+    ],
+]
+
+DEFAULT_MAPPINGS = {
+    DatetimeInfoOptions.TIME_OF_DAY.value: {
+        **dict.fromkeys(range(6), "night"),  # Midnight - 6am
+        **dict.fromkeys(range(6, 12), "morning"),  # 6am - Noon
+        **dict.fromkeys(range(12, 18), "afternoon"),  # Noon - 6pm
+        **dict.fromkeys(range(18, 24), "evening"),  # 6pm - Midnight
+    },
+    DatetimeInfoOptions.TIME_OF_MONTH.value: {
+        **dict.fromkeys(range(1, 11), "start"),
+        **dict.fromkeys(range(11, 21), "middle"),
+        **dict.fromkeys(range(21, 32), "end"),
+    },
+    DatetimeInfoOptions.TIME_OF_YEAR.value: {
+        **dict.fromkeys(range(3, 6), "spring"),  # Mar, Apr, May
+        **dict.fromkeys(range(6, 9), "summer"),  # Jun, Jul, Aug
+        **dict.fromkeys(range(9, 12), "autumn"),  # Sep, Oct, Nov
+        **dict.fromkeys([12, 1, 2], "winter"),  # Dec, Jan, Feb
+    },
+    DatetimeInfoOptions.DAY_OF_WEEK.value: {
+        1: "monday",
+        2: "tuesday",
+        3: "wednesday",
+        4: "thursday",
+        5: "friday",
+        6: "saturday",
+        7: "sunday",
+    },
+}
+
+INCLUDE_OPTIONS = list(DEFAULT_MAPPINGS.keys())
+
+RANGE_TO_MAP = {
+    DatetimeInfoOptions.TIME_OF_DAY.value: set(range(24)),
+    DatetimeInfoOptions.TIME_OF_MONTH.value: set(range(1, 32)),
+    DatetimeInfoOptions.TIME_OF_YEAR.value: set(range(1, 13)),
+    DatetimeInfoOptions.DAY_OF_WEEK.value: set(range(1, 8)),
+}
+
+DATETIME_ATTR = {
+    DatetimeInfoOptions.TIME_OF_DAY.value: "hour",
+    DatetimeInfoOptions.TIME_OF_MONTH.value: "day",
+    DatetimeInfoOptions.TIME_OF_YEAR.value: "month",
+    DatetimeInfoOptions.DAY_OF_WEEK.value: "weekday",
+}
+
+
+@beartype
+def extract_datetime_info(
+    columns: list[str],
+    datetime_mappings: dict[DatetimeInfoOptionStr, dict[int, str]] | None = None,
+    include: DatetimeInfoOptionList | DatetimeInfoOptionStr | None = None,
+) -> list[nw.Expr]:
+    """Get expression for extracting below components from datetime columns.
+
+    - time of day
+    - time of month
+    - time of year
+    - time of week
+
+    Parameters
+    ----------
+    columns:
+        List of names of the column to convert to datetime.
+
+
+    include:
+        Which datetime categorical information to extract
+
+    datetime_mappings:
+        Optional argument to define custom mappings for datetime values.
+        Keys of the dictionary must be contained in `include`.
+        All possible values of each feature must be included in the mappings,
+        ie, a mapping for `dayofweek` must include all values 1-7;
+        datetime_mappings = {
+                            "dayofweek": {
+                                        **{i: "week" for i in range(1,6)},
+                                        **{i: "week" for i in range(6,8)}
+                                        }
+                            }
+
+        The required ranges for each mapping are:
+            timeofday: 0-23
+            timeofmonth: 1-31
+            timeofyear: 1-12
+            dayofweek: 1-7
+
+        If an option is present in 'include' but no mappings are provided,
+        then default values from DEFAULT_MAPPINGS will be used for this
+        option.
+
+    Returns
+    -------
+    list[nw.Expr]: expressions for transformation
+
+    """
+    # initialise mappings with defaults,
+    # and overwrite with user provided mappings
+    # where possible
+    final_datetime_mappings = copy.deepcopy(DEFAULT_MAPPINGS)
+    for key in datetime_mappings:
+        final_datetime_mappings[key] = copy.deepcopy(
+            datetime_mappings[key],
+        )
+
+    # this is a situation where we know the values our mappings allow,
+    # so enum type is more appropriate than categorical and we
+    # will cast to this at the end
+    enums = {
+        include_option: nw.Enum(
+            sorted(set(final_datetime_mappings[include_option].values())),
+        )
+        for include_option in include
+    }
+
+    mappings_dict = {
+        col + "_" + include_option: final_datetime_mappings[include_option]
+        for col in columns
+        for include_option in include
+    }
+
+    return [
+        (
+            getattr(
+                nw.col(col).dt,
+                DATETIME_ATTR[include_option],
+            )()
+            .replace_strict(
+                mappings_dict[col + "_" + include_option],
+            )
+            .cast(enums[include_option])
+            .alias(col + "_" + include_option)
+        )
+        for col in columns
+        for include_option in include
+    ]
+
+
+class DatetimeComponentOptions(str, Enum):
+    """Contains options for DatetimeComponentExtractor."""
+
+    __slots__ = ()
+
+    HOUR = "hour"
+    DAY = "day"
+    MONTH = "month"
+    YEAR = "year"
+
+
+DatetimeComponentOptionStr = Annotated[
+    str,
+    Is[lambda s: s in DatetimeComponentOptions._value2member_map_],
+]
+DatetimeComponentOptionList = Annotated[
+    list,
+    Is[
+        lambda list_value: all(
+            entry in DatetimeComponentOptions._value2member_map_ for entry in list_value
+        )
+    ],
+]
+
+
+@beartype
+def extract_datetime_components(
+    columns: list[str],
+    include: DatetimeComponentOptionList | DatetimeComponentOptionStr,
+) -> list[nw.Expr]:
+    """Get expression for extracting below components from datetime columns.
+
+    - time of day
+    - time of month
+    - time of year
+    - time of week
+
+    Parameters
+    ----------
+    columns:
+        List of names of the column to convert to datetime.
+
+    include:
+        Which datetime categorical information to extract
+
+    Returns
+    -------
+    list[nw.Expr]: expressions for transformation
+
+    """
+    return [
+        (
+            getattr(
+                nw.col(col).dt,
+                include_option,
+            )()
+            .cast(
+                nw.Float32  # can't cast to int as may have nulls
+            )
+            .alias(col + "_" + include_option)
+        )
+        for col in columns
+        for include_option in include
+    ]
+
+
+class DatetimeSinusoidUnitsOptions(str, Enum):
+    """Options for units argument of DatetimeSinusoidCalculator."""
+
+    __slots__ = ()
+
+    YEAR = "year"
+    MONTH = "month"
+    DAY = "day"
+    HOUR = "hour"
+    MINUTE = "minute"
+    SECOND = "second"
+    MICROSECOND = "microsecond"
+
+
+DatetimeSinusoidUnitsOptionStr = Annotated[
+    str,
+    Is[lambda s: s in DatetimeSinusoidUnitsOptions._value2member_map_],
+]
+
+
+class MethodOptions(str, Enum):
+    """Options for method arg of DatetimeSinusoidCalculator."""
+
+    __slots__ = ()
+
+    SIN = "sin"
+    COS = "cos"
+
+
+MethodOptionStr = Annotated[
+    str,
+    Is[lambda s: s in MethodOptions._value2member_map_],
+]
+
+MethodOptionList = Annotated[
+    list,
+    Is[
+        lambda list_value: all(
+            entry in MethodOptions._value2member_map_ for entry in list_value
+        )
+    ],
+]
+
+NumberNotBool = Annotated[
+    int | float,
+    Is[
+        # exclude bools which would pass isinstance(..., (float, int))
+        lambda value: type(value) in {int, float}
+    ],
+]
+
+
+@beartype
+def extract_datetime_sinusoid_components(
+    columns: list[str],
+    period_dict: dict[str, NumberNotBool],
+    units_dict: dict[str, DatetimeSinusoidUnitsOptionStr],
+    method: MethodOptionStr | MethodOptionList,
+) -> list[nw.Expr]:
+    """Extract trig components from given units of datetime columns (e.g. month).
+
+    Parameters
+    ----------
+    columns:
+        Columns to take the sine or cosine of. Must be a datetime[64] column.
+
+    method:
+        Argument to specify which function is to be calculated. Accepted values are 'sin', 'cos' or a list containing both.
+
+    units_dict:
+        Which time unit the calculation is to be carried out on. Accepted values are 'year', 'month',
+        'day', 'hour', 'minute', 'second', 'microsecond'. dict containing key-value pairs of column
+        name and units to be used for that column.
+
+    period_dict:
+        The period of the output in the units specified above. To leave the period of the sinusoid output as 2 pi, specify 2*np.pi (or leave as default).
+        dict containing key-value pairs of column name and period to be used for that column.
+
+    Returns
+    -------
+    list[nw.Expr]: expressions for transformation
+
+    """
+    # first convert to desired units
+    return [
+        getattr(
+            getattr(
+                nw.col(column).dt,
+                units_dict[column],
+            )()
+            * (2 * np.pi / period_dict[column]),
+            trig_method,
+        )().alias(f"{trig_method}_{period_dict[column]}_{units_dict[column]}_{column}")
+        for column in columns
+        for trig_method in method
+    ]

--- a/tubular/functions/misc.py
+++ b/tubular/functions/misc.py
@@ -1,0 +1,94 @@
+"""Miscellaneous stateless transforms."""
+
+from enum import Enum
+from typing import Annotated, Any
+
+import narwhals as nw
+from beartype import beartype
+from beartype.vale import Is
+
+
+@beartype
+def set_columns_to_value(columns: list[str], value: Any) -> list[nw.Expr]:  # noqa: ANN401
+    """Set columns to fixed value.
+
+    Parameters
+    ----------
+    columns:
+        columns to set to provided value
+
+    value:
+        value to set columns to
+
+    Returns
+    -------
+    list[nw.Expr]: transform expressions
+
+    """
+    return [nw.lit(value).alias(c) for c in columns]
+
+
+@beartype
+def rename_columns(
+    columns: list[str], new_column_names: dict[str, str]
+) -> list[nw.Expr]:
+    """Rename columns with provided dictionary.
+
+    Parameters
+    ----------
+    columns:
+        columns to set to provided value
+
+    new_column_names:
+        dictionary of format col:new_name
+
+    Returns
+    -------
+    list[nw.Expr]: transform expressions
+
+    """
+    return [nw.col(c).alias(new_column_names[c]) for c in columns]
+
+
+class SimpleCastDtypes(str, Enum):
+    """Allowed dtypes for ColumnDtypeSetter."""
+
+    FLOAT64 = "Float64"
+    FLOAT32 = "Float32"
+    INT64 = "Int64"
+    INT32 = "Int32"
+    INT16 = "Int16"
+    INT8 = "Int8"
+    UINT64 = "UInt64"
+    UINT32 = "UInt32"
+    UINT16 = "UInt16"
+    UINT8 = "UInt8"
+    BOOLEAN = "Boolean"
+    STRING = "String"
+    CATEGORICAL = "Categorical"
+
+
+SimpleCastDtypesStr = Annotated[
+    str,
+    Is[lambda s: s in SimpleCastDtypes._value2member_map_],
+]
+
+
+@beartype
+def cast_columns(columns: list[str], dtype: SimpleCastDtypesStr) -> list[nw.Expr]:
+    """Rename columns with provided dictionary.
+
+    Parameters
+    ----------
+    columns:
+        columns to set to provided value
+
+    dtype:
+        dtype to cast to
+
+    Returns
+    -------
+    list[nw.Expr]: transform expressions
+
+    """
+    return [nw.col(col).cast(getattr(nw, dtype)) for col in columns]

--- a/tubular/functions/nominal.py
+++ b/tubular/functions/nominal.py
@@ -1,0 +1,87 @@
+"""Stateless nominal transforms."""
+
+from typing import Any, Literal
+
+import narwhals as nw
+import numpy as np
+from beartype import beartype
+
+
+@beartype
+def one_hot_encode_columns(
+    columns: list[str], categories: dict[str, list[Any]], separator: str
+) -> list[nw.Expr]:
+    """One hot encode columns for provided categories.
+
+    Parameters
+    ----------
+    columns:
+        columns to set to provided value
+
+    categories:
+        dict of categories to look for per column (column:categories)
+
+    separator:
+        character to separate col name and category name in output columns
+
+    Returns
+    -------
+    list[nw.Expr]: transform expressions
+
+    """
+    return [
+        (nw.col(c) == level).alias(c + separator + str(level))
+        for c in columns
+        for level in categories[c]
+    ]
+
+
+@beartype
+def numerically_encode_columns(  # noqa: PLR0917, PLR0913
+    columns: list[str],
+    mappings: dict[str, dict[str, float | int]],
+    unseen_levels_encodings: dict[str, float | np.float32 | np.float64] | None,
+    unseen_level_handling: bool | str | int | float | None,
+    return_dtypes: dict[str, Literal["Float64", "Float32"]],
+    column_to_encoded_columns: dict[str, list[str]],
+) -> list[nw.Expr]:
+    """Numerically encode columns with provided mappings.
+
+    Parameters
+    ----------
+    columns:
+        columns to set to provided value
+
+    mappings:
+        mappings per level for each column (column:level:value)
+
+    unseen_levels_encodings:
+        mapping values for unseen levels per encoded column
+
+    unseen_level_handling:
+        controls whether to use unseen level handling
+
+    return_dtypes:
+        return types for each encoded column
+
+    column_to_encoded_columns:
+        dict mapping columns to the output columns they produce
+
+    Returns
+    -------
+    list[nw.Expr]: transform expressions
+
+    """
+    return [
+        nw.col(col)
+        .alias(encoded_col)
+        .replace_strict(
+            mappings[encoded_col],
+            default=unseen_levels_encodings[encoded_col]
+            if unseen_level_handling
+            else None,
+        )
+        .cast(getattr(nw, return_dtypes[encoded_col]))
+        for col in columns
+        for encoded_col in column_to_encoded_columns[col]
+    ]

--- a/tubular/functions/numeric.py
+++ b/tubular/functions/numeric.py
@@ -1,0 +1,56 @@
+"""Stateless numeric transforms."""
+
+import narwhals as nw
+from beartype import beartype
+
+from tubular.types import FloatTypeAnnotated, ListOfTwoStrs
+
+
+@beartype
+def get_difference_of_two_columns(
+    columns: ListOfTwoStrs,
+) -> nw.Expr:
+    """Get difference column[0]-column[1].
+
+    Parameters
+    ----------
+    columns:
+        columns to diff
+
+    Returns
+    -------
+    nw.Expr: transform expressions
+
+    """
+    return (nw.col(columns[0]) - nw.col(columns[1])).alias(
+        f"{columns[0]}_minus_{columns[1]}"
+    )
+
+
+@beartype
+def get_ratio_of_two_columns(
+    columns: ListOfTwoStrs,
+    return_dtype: FloatTypeAnnotated,
+) -> nw.Expr:
+    """Divide column[0] by column[1].
+
+    Parameters
+    ----------
+    columns:
+        columns to take ratio of
+
+    return_dtype:
+        Float64 or Float32
+
+    Returns
+    -------
+    nw.Expr: transform expressions
+
+    """
+    return (
+        nw.when(nw.col(columns[1]) != 0)
+        .then(nw.col(columns[0]) / nw.col(columns[1]))
+        .otherwise(None)
+        .cast(getattr(nw, return_dtype))
+        .alias(f"{columns[0]}_divided_by_{columns[1]}")
+    )

--- a/tubular/functions/strings.py
+++ b/tubular/functions/strings.py
@@ -28,26 +28,3 @@ def remove_characters_from_string_columns(
 
     """
     return [nw.col(col).str.replace_all(characters_formatted, "") for col in columns]
-
-
-@beartype
-def extract_string_components(
-    columns: list[str], by: str, return_n_components: int
-) -> list[nw.Expr]:
-    """Get expression for extracting components from a str columns, split by provided character.
-
-    Returns
-    -------
-    list[nw.Expr]: expressions for transformation
-
-    """
-    split_exprs = {col: nw.col(col).str.split(by=by) for col in columns}
-    return [
-        nw.when(split_exprs[col].list.len() > i)
-        .then(split_exprs[col])
-        .otherwise(None)
-        .list.get(i)
-        .alias(f"{col}_split_by_{by}_entry_{i}")
-        for col in columns
-        for i in range(return_n_components)
-    ]

--- a/tubular/functions/strings.py
+++ b/tubular/functions/strings.py
@@ -1,8 +1,10 @@
 """Stateless string transforms."""
 
 import narwhals as nw
+from beartype import beartype
 
 
+@beartype
 def convert_string_columns_to_lowercase(columns: list[str]) -> list[nw.Expr]:
     """Get expression for converting columns to lowercase.
 
@@ -14,6 +16,7 @@ def convert_string_columns_to_lowercase(columns: list[str]) -> list[nw.Expr]:
     return [nw.col(col).str.to_lowercase() for col in columns]
 
 
+@beartype
 def remove_characters_from_string_columns(
     columns: list[str], characters_formatted: str
 ) -> list[nw.Expr]:
@@ -25,3 +28,26 @@ def remove_characters_from_string_columns(
 
     """
     return [nw.col(col).str.replace_all(characters_formatted, "") for col in columns]
+
+
+@beartype
+def extract_string_components(
+    columns: list[str], by: str, return_n_components: int
+) -> list[nw.Expr]:
+    """Get expression for extracting components from a str columns, split by provided character.
+
+    Returns
+    -------
+    list[nw.Expr]: expressions for transformation
+
+    """
+    split_exprs = {col: nw.col(col).str.split(by=by) for col in columns}
+    return [
+        nw.when(split_exprs[col].list.len() > i)
+        .then(split_exprs[col])
+        .otherwise(None)
+        .list.get(i)
+        .alias(f"{col}_split_by_{by}_entry_{i}")
+        for col in columns
+        for i in range(return_n_components)
+    ]

--- a/tubular/misc.py
+++ b/tubular/misc.py
@@ -2,12 +2,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
-from typing import Annotated, Any
+from typing import Any
 
 import narwhals as nw
 from beartype import beartype
-from beartype.vale import Is
 
 from tubular._utils import (
     _convert_dataframe_to_narwhals,
@@ -15,6 +13,12 @@ from tubular._utils import (
     block_from_json,
 )
 from tubular.base import BaseTransformer, register
+from tubular.functions.misc import (
+    SimpleCastDtypesStr,
+    cast_columns,
+    rename_columns,
+    set_columns_to_value,
+)
 from tubular.mixins import DropOriginalMixin
 from tubular.types import (
     DataFrame,
@@ -117,6 +121,19 @@ class SetValueTransformer(BaseTransformer):
 
         return json_dict
 
+    def get_transform_exprs(self) -> list[nw.Expr]:
+        """Get transform expressions.
+
+        Returns
+        -------
+        list[nw.Expr]: transform expressions for class
+
+        """
+        return set_columns_to_value(
+            columns=self.columns,
+            value=self.value,
+        )
+
     @beartype
     def transform(self, X: DataFrame) -> DataFrame:
         """Set columns to value.
@@ -159,7 +176,9 @@ class SetValueTransformer(BaseTransformer):
 
         X = super().transform(X, return_native_override=False)
 
-        X = X.with_columns([nw.lit(self.value).alias(c) for c in self.columns])
+        transform_exprs = self.get_transform_exprs()
+
+        X = X.with_columns(*transform_exprs) if transform_exprs else X
 
         return _return_narwhals_or_native_dataframe(X, self.return_native)
 
@@ -338,6 +357,19 @@ class RenameColumnsTransformer(BaseTransformer, DropOriginalMixin):
 
         return json_dict
 
+    def get_transform_exprs(self) -> list[nw.Expr]:
+        """Get transform expressions.
+
+        Returns
+        -------
+        list[nw.Expr]: transform expressions for class
+
+        """
+        return rename_columns(
+            columns=self.columns,
+            new_column_names=self.new_column_names,
+        )
+
     @beartype
     def transform(self, X: DataFrame) -> DataFrame:
         """Create column copies.
@@ -393,37 +425,13 @@ class RenameColumnsTransformer(BaseTransformer, DropOriginalMixin):
 
         X = _convert_dataframe_to_narwhals(X)
 
-        X = X.with_columns(
-            [nw.col(c).alias(self.new_column_names[c]) for c in self.columns]
-        )
+        transform_exprs = self.get_transform_exprs()
+
+        X = X.with_columns(*transform_exprs) if transform_exprs else X
 
         X = DropOriginalMixin.drop_original_column(X, self.drop_original, self.columns)
 
         return _return_narwhals_or_native_dataframe(X, self.return_native)
-
-
-class SimpleCastDtypes(str, Enum):
-    """Allowed dtypes for ColumnDtypeSetter."""
-
-    FLOAT64 = "Float64"
-    FLOAT32 = "Float32"
-    INT64 = "Int64"
-    INT32 = "Int32"
-    INT16 = "Int16"
-    INT8 = "Int8"
-    UINT64 = "UInt64"
-    UINT32 = "UInt32"
-    UINT16 = "UInt16"
-    UINT8 = "UInt8"
-    BOOLEAN = "Boolean"
-    STRING = "String"
-    CATEGORICAL = "Categorical"
-
-
-SimpleCastDtypesStr = Annotated[
-    str,
-    Is[lambda s: s in SimpleCastDtypes._value2member_map_],
-]
 
 
 @register
@@ -524,6 +532,19 @@ class ColumnDtypeSetter(BaseTransformer):
 
         return json_dict
 
+    def get_transform_exprs(self) -> list[nw.Expr]:
+        """Get transform expressions.
+
+        Returns
+        -------
+        list[nw.Expr]: transform expressions for class
+
+        """
+        return cast_columns(
+            columns=self.columns,
+            dtype=self.dtype,
+        )
+
     def transform(self, X: DataFrame) -> DataFrame:
         """Transform data.
 
@@ -567,8 +588,8 @@ class ColumnDtypeSetter(BaseTransformer):
             )
 
         else:
-            X = X.with_columns(
-                [nw.col(col).cast(getattr(nw, self.dtype)) for col in self.columns]
-            )
+            transform_exprs = self.get_transform_exprs()
+
+            X = X.with_columns(*transform_exprs) if transform_exprs else X
 
         return _return_narwhals_or_native_dataframe(X, self.return_native)

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -24,6 +24,7 @@ from tubular._utils import (
     block_from_json,
 )
 from tubular.base import BaseTransformer, register
+from tubular.functions.nominal import numerically_encode_columns, one_hot_encode_columns
 from tubular.mapping import BaseMappingTransformer, BaseMappingTransformMixin
 from tubular.mixins import DropOriginalMixin, WeightColumnMixin
 from tubular.types import (
@@ -1314,6 +1315,25 @@ class MeanResponseTransformer(
                     c: unseen_level_results[c].item(0) for c in self.encoded_columns
                 }
 
+    def get_transform_exprs(self) -> list[nw.Expr]:
+        """Get transform expressions.
+
+        Returns
+        -------
+        list[nw.Expr]: transform expressions for class
+
+        """
+        return numerically_encode_columns(
+            columns=self.columns,
+            mappings=self.mappings,
+            unseen_levels_encodings=self.unseen_levels_encoding_dict
+            if self.unseen_level_handling
+            else None,
+            return_dtypes=self.return_dtypes,
+            column_to_encoded_columns=self.column_to_encoded_columns,
+            unseen_level_handling=self.unseen_level_handling,
+        )
+
     @beartype
     def transform(self, X: DataFrame) -> DataFrame:
         """Apply mean response encoding stored in the mappings attribute to columns.
@@ -1395,25 +1415,13 @@ class MeanResponseTransformer(
             return_native_override=False,
         )
 
-        transform_expressions = {
-            encoded_col: nw.col(col)
-            .alias(encoded_col)
-            .replace_strict(
-                self.mappings[encoded_col],
-                default=self.unseen_levels_encoding_dict[encoded_col]
-                if self.unseen_level_handling
-                else None,
-            )
-            .cast(getattr(nw, self.return_dtypes[encoded_col]))
-            for col in self.columns
-            for encoded_col in self.column_to_encoded_columns[col]
-        }
+        transform_exprs = self.get_transform_exprs()
 
         X = (
             X.with_columns(
-                **transform_expressions,
+                *transform_exprs,
             )
-            if transform_expressions
+            if transform_exprs
             else X
         )
 
@@ -1780,6 +1788,20 @@ class OneHotEncodingTransformer(
             column + self.separator + str(level) for level in self.categories_[column]
         ]
 
+    def get_transform_exprs(self) -> list[nw.Expr]:
+        """Get transform expressions.
+
+        Returns
+        -------
+        list[nw.Expr]: transform expressions for class
+
+        """
+        return one_hot_encode_columns(
+            columns=self.columns,
+            categories=self.categories_,
+            separator=self.separator,
+        )
+
     @beartype
     def transform(
         self,
@@ -1842,22 +1864,9 @@ class OneHotEncodingTransformer(
         X = _convert_dataframe_to_narwhals(X)
         X = BaseTransformer.transform(self, X, return_native_override=False)
 
-        transform_expressions = {}
-        for c in self.columns:
-            for level in self.categories_[c]:
-                if c + self.separator + str(level) in self.new_feature_names_[c]:
-                    transform_expressions[c + self.separator + str(level)] = (
-                        nw.col(c) == level
-                    )
+        transform_exprs = self.get_transform_exprs()
 
-        # make column order consistent
-        sorted_keys = sorted(transform_expressions.keys())
-
-        X = (
-            X.with_columns(**{key: transform_expressions[key] for key in sorted_keys})
-            if transform_expressions
-            else X
-        )
+        X = X.with_columns(*transform_exprs) if transform_exprs else X
 
         # Drop original columns if self.drop_original is True
         X = DropOriginalMixin.drop_original_column(

--- a/tubular/numeric.py
+++ b/tubular/numeric.py
@@ -24,6 +24,10 @@ from tubular._utils import (
     block_from_json,
 )
 from tubular.base import BaseTransformer, DataFrameMethodTransformer, register
+from tubular.functions.numeric import (
+    get_difference_of_two_columns,
+    get_ratio_of_two_columns,
+)
 from tubular.mixins import (
     CheckNumericMixin,
     DropOriginalMixin,
@@ -616,6 +620,16 @@ class DifferenceTransformer(BaseNumericTransformer):
         self.new_column_name = f"{columns[0]}_minus_{columns[1]}"
         self.is_fitted_ = True  # Does not fit
 
+    def get_transform_exprs(self) -> list[nw.Expr]:
+        """Get transform expressions.
+
+        Returns
+        -------
+        list[nw.Expr]: transform expressions for class
+
+        """
+        return get_difference_of_two_columns(columns=self.columns)
+
     @beartype
     def transform(
         self,
@@ -659,10 +673,9 @@ class DifferenceTransformer(BaseNumericTransformer):
 
         X = super().transform(X, return_native_override=False)
 
-        # Create the subtraction expression
-        expr = nw.col(self.columns[0]) - nw.col(self.columns[1])
+        transform_expr = self.get_transform_exprs()
 
-        X = X.with_columns(expr.alias(self.new_column_name))
+        X = X.with_columns(transform_expr)
 
         return _return_narwhals_or_native_dataframe(X, self.return_native)
 
@@ -779,6 +792,19 @@ class RatioTransformer(BaseNumericTransformer):
         self.return_dtype = return_dtype
         self.is_fitted_ = True  # Does not fit
 
+    def get_transform_exprs(self) -> list[nw.Expr]:
+        """Get transform expressions.
+
+        Returns
+        -------
+        list[nw.Expr]: transform expressions for class
+
+        """
+        return get_ratio_of_two_columns(
+            columns=self.columns,
+            return_dtype=self.return_dtype,
+        )
+
     @beartype
     def transform(
         self,
@@ -820,17 +846,9 @@ class RatioTransformer(BaseNumericTransformer):
         X = _convert_dataframe_to_narwhals(X)
         X = super().transform(X, return_native_override=False)
 
-        # Create the division expression
-        expr = (
-            nw.when(nw.col(self.columns[1]) != 0)
-            .then(nw.col(self.columns[0]) / nw.col(self.columns[1]))
-            .otherwise(None)
-            .cast(getattr(nw, self.return_dtype))
-        )
+        transform_expr = self.get_transform_exprs()
 
-        # Add the new column
-        new_column_name = f"{self.columns[0]}_divided_by_{self.columns[1]}"
-        X = X.with_columns(expr.alias(new_column_name))
+        X = X.with_columns(transform_expr)
 
         return _return_narwhals_or_native_dataframe(X, self.return_native)
 


### PR DESCRIPTION
added get_transform_exprs methods to all transformers where this was simple/just involved moving code around, moved expression logic into new functions module so this can be used separately to transformer classes.

New functions are tested through the existing transformer tests, so proposal is to not test separately