### PR TITLE
added get_transform_exprs method to capping transformers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,7 @@ Changed
 - added LowerCaseTransformer and RemoveCharactersTransformer to string module
 - added functions module for stateless transforms
 - removed narwhals private import from nominal module `#725 <https://github.com/azukds/tubular/issues/725>_`
+- added get_transform_exprs methods to capping transformers
 
 3.3.0 (30/04/2026)
 ------------------

--- a/tests/capping/test_BaseCappingTransformer.py
+++ b/tests/capping/test_BaseCappingTransformer.py
@@ -11,7 +11,6 @@ from tests.base_tests import (
     DummyWeightColumnMixinTests,
     GenericFitTests,
     GenericInitTests,
-    GenericTransformTests,
     WeightColumnFitMixinTests,
     WeightColumnInitMixinTests,
 )
@@ -408,7 +407,7 @@ class GenericCappingFitTests(
         )
 
 
-class GenericCappingTransformTests(GenericTransformTests):
+class GenericCappingTransformTests:
     """Tests for BaseCappingTransformer.transform()."""
 
     @classmethod
@@ -431,15 +430,14 @@ class GenericCappingTransformTests(GenericTransformTests):
 
         return df.to_native()
 
+    @pytest.mark.parametrize(
+        "transformer_name", ["CappingTransformer", "OutOfRangeNullTransformer"]
+    )
     @pytest.mark.parametrize("lazy", [True, False])
     @pytest.mark.parametrize("from_json", [True, False])
     @pytest.mark.parametrize("library", ["pandas", "polars"])
     def test_non_cap_column_left_untouched(
-        self,
-        initialized_transformers,
-        library,
-        from_json,
-        lazy,
+        self, initialized_transformers, library, from_json, lazy, transformer_name
     ):
         """Test that capping is applied only to specific columns, others remain the same."""
 
@@ -447,7 +445,7 @@ class GenericCappingTransformTests(GenericTransformTests):
 
         expected = self.expected_df_2(library=library)
 
-        transformer = initialized_transformers[self.transformer_name]
+        transformer = initialized_transformers[transformer_name]
 
         if _check_if_skip_test(transformer, df, lazy=lazy, from_json=from_json):
             return
@@ -481,6 +479,9 @@ class GenericCappingTransformTests(GenericTransformTests):
                 df_expected_row[columns_to_test],
             )
 
+    @pytest.mark.parametrize(
+        "transformer_name", ["CappingTransformer", "OutOfRangeNullTransformer"]
+    )
     @pytest.mark.parametrize("lazy", [True, False])
     @pytest.mark.parametrize("library", ["pandas", "polars"])
     @pytest.mark.parametrize(
@@ -495,10 +496,11 @@ class GenericCappingTransformTests(GenericTransformTests):
         library,
         from_json,
         lazy,
+        transformer_name,
     ):
         """Test that the replacements from fit are not changed in transform."""
 
-        transformer = initialized_transformers[self.transformer_name]
+        transformer = initialized_transformers[transformer_name]
 
         df = d.create_df_3(library=library)
 
@@ -527,6 +529,9 @@ class GenericCappingTransformTests(GenericTransformTests):
                 f"learnt_value {fit_value} changed by transform, expected {learnt_values} but got {new_learnt_values}"
             )
 
+    @pytest.mark.parametrize(
+        "transformer_name", ["CappingTransformer", "OutOfRangeNullTransformer"]
+    )
     @pytest.mark.parametrize("lazy", [True, False])
     @pytest.mark.parametrize("library", ["pandas", "polars"])
     @pytest.mark.parametrize("from_json", [True, False])
@@ -537,13 +542,14 @@ class GenericCappingTransformTests(GenericTransformTests):
         library,
         from_json,
         lazy,
+        transformer_name,
     ):
         """Test that transform will raise an error if a column to transform is not numeric."""
 
-        args = minimal_attribute_dict[self.transformer_name].copy()
+        args = minimal_attribute_dict[transformer_name].copy()
         args["capping_values"] = {"a": [1, 2]}
 
-        transformer = uninitialized_transformers[self.transformer_name](**args)
+        transformer = uninitialized_transformers[transformer_name](**args)
         df = d.create_df_5(library=library)
 
         if _check_if_skip_test(transformer, df, lazy=lazy, from_json=from_json):
@@ -565,10 +571,13 @@ class GenericCappingTransformTests(GenericTransformTests):
 
         with pytest.raises(
             TypeError,
-            match=rf"{self.transformer_name}: The following columns are not numeric in X; \['a'\]",
+            match=rf"{transformer_name}: The following columns are not numeric in X; \['a'\]",
         ):
             transformer.transform(_convert_to_lazy(df, lazy))
 
+    @pytest.mark.parametrize(
+        "transformer_name", ["CappingTransformer", "OutOfRangeNullTransformer"]
+    )
     @pytest.mark.parametrize("lazy", [True, False])
     @pytest.mark.parametrize("library", ["pandas", "polars"])
     def test_quantile_capping_values_not_fit_error(
@@ -577,15 +586,16 @@ class GenericCappingTransformTests(GenericTransformTests):
         uninitialized_transformers,
         library,
         lazy,
+        transformer_name,
     ):
         """Test that transform will raise an error if capping_values attr has not fit"""
         df = d.create_df_9(library=library)
 
-        args = minimal_attribute_dict[self.transformer_name].copy()
+        args = minimal_attribute_dict[transformer_name].copy()
         args["quantiles"] = {"a": [0.1, 0.2]}
         args["capping_values"] = None
 
-        transformer = uninitialized_transformers[self.transformer_name](**args)
+        transformer = uninitialized_transformers[transformer_name](**args)
 
         # if transformer is not polars compatible, skip polars test
         if not transformer.polars_compatible and isinstance(df, pl.DataFrame):
@@ -593,10 +603,13 @@ class GenericCappingTransformTests(GenericTransformTests):
 
         with pytest.raises(
             ValueError,
-            match=f"This {self.transformer_name} instance is not fitted yet. Call 'fit' with appropriate arguments before using this estimator",
+            match=f"This {transformer_name} instance is not fitted yet. Call 'fit' with appropriate arguments before using this estimator",
         ):
             transformer.transform(_convert_to_lazy(df, lazy))
 
+    @pytest.mark.parametrize(
+        "transformer_name", ["CappingTransformer", "OutOfRangeNullTransformer"]
+    )
     @pytest.mark.parametrize("lazy", [True, False])
     @pytest.mark.parametrize("library", ["pandas", "polars"])
     def test_replacement_values_not_fit_error(
@@ -605,15 +618,16 @@ class GenericCappingTransformTests(GenericTransformTests):
         uninitialized_transformers,
         library,
         lazy,
+        transformer_name,
     ):
         """Test that transform will raise an error if replacement values attr has not fit"""
         df = d.create_df_9(library=library)
 
-        args = minimal_attribute_dict[self.transformer_name].copy()
+        args = minimal_attribute_dict[transformer_name].copy()
         args["quantiles"] = {"a": [0.1, 0.2]}
         args["capping_values"] = None
 
-        transformer = uninitialized_transformers[self.transformer_name](**args)
+        transformer = uninitialized_transformers[transformer_name](**args)
 
         # if transformer is not polars compatible, skip polars test
         if not transformer.polars_compatible and isinstance(df, pl.DataFrame):
@@ -621,10 +635,13 @@ class GenericCappingTransformTests(GenericTransformTests):
 
         with pytest.raises(
             ValueError,
-            match=f"This {self.transformer_name} instance is not fitted yet. Call 'fit' with appropriate arguments before using this estimator",
+            match=f"This {transformer_name} instance is not fitted yet. Call 'fit' with appropriate arguments before using this estimator",
         ):
             transformer.transform(_convert_to_lazy(df, lazy))
 
+    @pytest.mark.parametrize(
+        "transformer_name", ["CappingTransformer", "OutOfRangeNullTransformer"]
+    )
     @pytest.mark.parametrize("lazy", [True, False])
     @pytest.mark.parametrize("library", ["pandas", "polars"])
     @pytest.mark.parametrize("from_json", [True, False])
@@ -635,15 +652,16 @@ class GenericCappingTransformTests(GenericTransformTests):
         library,
         from_json,
         lazy,
+        transformer_name,
     ):
         """Test that attributes are unchanged after transform is run."""
         df = d.create_df_9(library=library)
 
-        args = minimal_attribute_dict[self.transformer_name].copy()
+        args = minimal_attribute_dict[transformer_name].copy()
         args["quantiles"] = {"a": [0.2, 1], "b": [0, 1]}
         args["capping_values"] = None
 
-        transformer = uninitialized_transformers[self.transformer_name](**args)
+        transformer = uninitialized_transformers[transformer_name](**args)
 
         if _check_if_skip_test(transformer, df, lazy=lazy, from_json=from_json):
             return
@@ -651,7 +669,7 @@ class GenericCappingTransformTests(GenericTransformTests):
         transformer.fit(_convert_to_lazy(df, lazy))
         transformer = _handle_from_json(transformer, from_json)
 
-        transformer2 = uninitialized_transformers[self.transformer_name](**args)
+        transformer2 = uninitialized_transformers[transformer_name](**args)
 
         if _check_if_skip_test(transformer2, df, lazy=lazy, from_json=from_json):
             return
@@ -678,51 +696,9 @@ class GenericCappingTransformTests(GenericTransformTests):
 
         return dataframe_init_dispatch(dataframe_dict=df_dict, library=library)
 
-    @pytest.mark.parametrize("lazy", [True, False])
-    @pytest.mark.parametrize("library", ["pandas", "polars"])
-    @pytest.mark.parametrize("from_json", [True, False])
-    def test_expected_output_min_and_max_combinations(
-        self,
-        minimal_attribute_dict,
-        uninitialized_transformers,
-        library,
-        from_json,
-        lazy,
-    ):
-        """Test that capping is applied correctly in transform."""
-
-        df = d.create_df_3(library=library)
-        expected = self.expected_df_1(library=library)
-
-        args = minimal_attribute_dict[self.transformer_name].copy()
-        args["capping_values"] = {"a": [2, 5], "b": [None, 7], "c": [0, None]}
-
-        transformer = uninitialized_transformers[self.transformer_name](**args)
-
-        if _check_if_skip_test(transformer, df, lazy=lazy, from_json=from_json):
-            return
-
-        transformer.fit(_convert_to_lazy(df, lazy))
-        transformer = _handle_from_json(transformer, from_json)
-
-        df_transformed = transformer.transform(_convert_to_lazy(df, lazy))
-
-        assert_frame_equal_dispatch(_collect_frame(df_transformed, lazy), expected)
-
-        # Check outcomes for single rows
-        df = nw.from_native(df)
-        expected = nw.from_native(expected)
-        for i in range(len(df)):
-            df_transformed_row = transformer.transform(
-                _convert_to_lazy(df[[i]].to_native(), lazy)
-            )
-            df_expected_row = expected[[i]].to_native()
-
-            assert_frame_equal_dispatch(
-                _collect_frame(df_transformed_row, lazy),
-                df_expected_row,
-            )
-
+    @pytest.mark.parametrize(
+        "transformer_name", ["CappingTransformer", "OutOfRangeNullTransformer"]
+    )
     @pytest.mark.parametrize("lazy", [True, False])
     @pytest.mark.parametrize(
         "minimal_dataframe_lookup",
@@ -735,6 +711,7 @@ class GenericCappingTransformTests(GenericTransformTests):
         uninitialized_transformers,
         minimal_dataframe_lookup,
         lazy,
+        transformer_name,
     ):
         """Test error is thrown if all rows are filtered during fit.
 
@@ -742,14 +719,14 @@ class GenericCappingTransformTests(GenericTransformTests):
         the usual mixin test of this name.
         """
 
-        args = minimal_attribute_dict[self.transformer_name].copy()
+        args = minimal_attribute_dict[transformer_name].copy()
         weight_column = "weight_column"
         args["capping_values"] = None
         args["quantiles"] = {"a": [0.01, 0.99]}
         args["weights_column"] = weight_column
 
-        df = minimal_dataframe_lookup[self.transformer_name]
-        uninitialized_transformer = uninitialized_transformers[self.transformer_name]
+        df = minimal_dataframe_lookup[transformer_name]
+        uninitialized_transformer = uninitialized_transformers[transformer_name]
 
         df = nw.from_native(df)
         df = df.with_columns(nw.lit(0).alias("weight_column"))

--- a/tests/capping/test_CappingTransformer.py
+++ b/tests/capping/test_CappingTransformer.py
@@ -1,8 +1,11 @@
+import narwhals as nw
 import polars as pl
 import pytest
 
+import tests.test_data as d
 from tests.base_tests import (
     EmptyCappingsFitTransformPassTests,
+    GenericTransformTests,
     OtherBaseBehaviourTests,
     OtherBaseBehaviourTestsNumeric,
 )
@@ -11,7 +14,14 @@ from tests.capping.test_BaseCappingTransformer import (
     GenericCappingInitTests,
     GenericCappingTransformTests,
 )
-from tests.utils import assert_frame_equal_dispatch, dataframe_init_dispatch
+from tests.utils import (
+    _check_if_skip_test,
+    _collect_frame,
+    _convert_to_lazy,
+    _handle_from_json,
+    assert_frame_equal_dispatch,
+    dataframe_init_dispatch,
+)
 from tubular.capping import CappingTransformer
 
 
@@ -31,12 +41,59 @@ class TestFit(GenericCappingFitTests):
         cls.transformer_name = "CappingTransformer"
 
 
-class TestTransform(GenericCappingTransformTests):
+class TestTransform(GenericCappingTransformTests, GenericTransformTests):
     """Tests for CappingTransformer.transform()."""
 
     @classmethod
     def setup_class(cls):
         cls.transformer_name = "CappingTransformer"
+
+    @pytest.mark.parametrize("lazy", [True, False])
+    @pytest.mark.parametrize("library", ["pandas", "polars"])
+    @pytest.mark.parametrize("from_json", [True, False])
+    def test_expected_output_min_and_max_combinations(
+        self,
+        minimal_attribute_dict,
+        uninitialized_transformers,
+        library,
+        from_json,
+        lazy,
+    ):
+        """Test that capping is applied correctly in transform."""
+
+        df = d.create_df_3(library=library)
+        expected = self.expected_df_1(library=library)
+
+        args = minimal_attribute_dict[self.transformer_name].copy()
+        args["capping_values"] = {"a": [2, 5], "b": [None, 7], "c": [0, None]}
+
+        transformer = uninitialized_transformers[self.transformer_name](**args)
+
+        if _check_if_skip_test(transformer, df, lazy=lazy, from_json=from_json):
+            return
+
+        transformer.fit(_convert_to_lazy(df, lazy))
+        transformer = _handle_from_json(transformer, from_json)
+
+        df_transformed = transformer.transform(_convert_to_lazy(df, lazy))
+
+        print(df_transformed)
+        print(expected)
+        assert_frame_equal_dispatch(_collect_frame(df_transformed, lazy), expected)
+
+        # Check outcomes for single rows
+        df = nw.from_native(df)
+        expected = nw.from_native(expected)
+        for i in range(len(df)):
+            df_transformed_row = transformer.transform(
+                _convert_to_lazy(df[[i]].to_native(), lazy)
+            )
+            df_expected_row = expected[[i]].to_native()
+
+            assert_frame_equal_dispatch(
+                _collect_frame(df_transformed_row, lazy),
+                df_expected_row,
+            )
 
 
 class TestLazyYSupport:

--- a/tests/capping/test_OutOfRangeNullTransformer.py
+++ b/tests/capping/test_OutOfRangeNullTransformer.py
@@ -5,6 +5,7 @@ import pytest
 import tests.test_data as d
 from tests.base_tests import (
     EmptyCappingsFitTransformPassTests,
+    GenericTransformTests,
     OtherBaseBehaviourTests,
     OtherBaseBehaviourTestsNumeric,
 )
@@ -94,7 +95,7 @@ class TestFit(GenericCappingFitTests):
         )
 
 
-class TestTransform(GenericCappingTransformTests):
+class TestTransform(GenericCappingTransformTests, GenericTransformTests):
     """Tests for OutOfRangeNullTransformer.transform()."""
 
     @classmethod
@@ -177,7 +178,7 @@ class TestLazyYSupport:
 
         expected = pl.DataFrame(
             {
-                "a": [1, 2, 3, 4, None],
+                "a": [1.0, 2.0, 3.0, 4.0, None],
                 "b": [1.0, 2.0, 3.0, 4.0, None],
             }
         )

--- a/tubular/capping.py
+++ b/tubular/capping.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 import copy
 import warnings
-from typing import Annotated
 
 import narwhals as nw
 import numpy as np
 from beartype import beartype
-from beartype.vale import Is
 
 from tubular._stats import _weighted_quantile_expr
 from tubular._utils import (
@@ -19,24 +17,14 @@ from tubular._utils import (
     _return_narwhals_or_native_dataframe,
 )
 from tubular.base import block_from_json, register
+from tubular.functions.capping import (
+    CappingValues,
+    cap_columns,
+    set_out_of_range_to_none,
+)
 from tubular.mixins import WeightColumnMixin
 from tubular.numeric import BaseNumericTransformer
-from tubular.types import DataFrame, LazyFrame, Number, Series
-
-CappingValues = Annotated[
-    list[Number | None],
-    Is[
-        lambda list_arg: (
-            (len(list_arg) == 2)  # noqa: PLR2004
-            & (
-                all(
-                    (isinstance(value, (int, float)) or value is None)
-                    for value in list_arg
-                )
-            )
-        )
-    ],
-]
+from tubular.types import DataFrame, FloatTypeAnnotated, LazyFrame, Number, Series
 
 
 @register
@@ -463,127 +451,6 @@ class BaseCappingTransformer(BaseNumericTransformer, WeightColumnMixin):
             float(value) if value is not None else value for value in interp_quantiles
         ]
 
-    @beartype
-    def transform(
-        self,
-        X: DataFrame,
-        return_native_override: bool | None = None,
-    ) -> DataFrame:
-        """Apply capping to columns in X.
-
-        If cap_value_max is set, any values above cap_value_max will be set to cap_value_max. If cap_value_min
-        is set any values below cap_value_min will be set to cap_value_min. Only works or numeric columns.
-
-        Parameters
-        ----------
-        X : DataFrame
-            Data to apply capping to.
-
-        return_native_override: Optional[bool]
-            Option to override return_native attr in transformer, useful when calling parent
-            methods
-
-        Returns
-        -------
-        X : DataFrame
-            Transformed input X with min and max capping applied to the specified columns.
-
-        Examples
-        --------
-        ```pycon
-        >>> import polars as pl
-
-        >>> transformer = BaseCappingTransformer(
-        ...     capping_values={"a": [10, 20], "b": [1, 3]},
-        ... )
-
-        >>> test_df = pl.DataFrame({"a": [1, 15, 18, 25], "b": [6, 2, 7, 1], "c": [1, 2, 3, 4]})
-
-        >>> transformer.transform(test_df)
-        shape: (4, 3)
-        ┌─────┬─────┬─────┐
-        │ a   ┆ b   ┆ c   │
-        │ --- ┆ --- ┆ --- │
-        │ i64 ┆ i64 ┆ i64 │
-        ╞═════╪═════╪═════╡
-        │ 10  ┆ 3   ┆ 1   │
-        │ 15  ┆ 2   ┆ 2   │
-        │ 18  ┆ 3   ┆ 3   │
-        │ 20  ┆ 1   ┆ 4   │
-        └─────┴─────┴─────┘
-
-        ```
-
-        """
-        self.check_is_fitted(["_replacement_values"])
-
-        X = _convert_dataframe_to_narwhals(X)
-
-        schema = X.collect_schema()
-
-        return_native = self._process_return_native(return_native_override)
-
-        X = super().transform(X, return_native_override=False)
-
-        dict_attrs = ["_replacement_values"]
-
-        if self.quantiles:
-            self.check_is_fitted(["quantile_capping_values"])
-
-            capping_values_for_transform = self.quantile_capping_values
-
-            dict_attrs = [*dict_attrs, "quantile_capping_values"]
-
-        else:
-            capping_values_for_transform = self.capping_values
-
-            dict_attrs = [*dict_attrs, "capping_values"]
-
-        exprs = {}
-        for col in self.columns:
-            cap_value_min = capping_values_for_transform[col][0]
-            cap_value_max = capping_values_for_transform[col][1]
-
-            replacement_min = self._replacement_values[col][0]
-            replacement_max = self._replacement_values[col][1]
-
-            if cap_value_min is not None and cap_value_max is not None:
-                col_expr = (
-                    nw.when(nw.col(col) < cap_value_min)
-                    .then(replacement_min)
-                    .otherwise(
-                        nw.when(nw.col(col) > cap_value_max)
-                        .then(replacement_max)
-                        .otherwise(nw.col(col)),
-                    )
-                )
-            elif cap_value_min is not None:
-                col_expr = (
-                    nw.when(nw.col(col) < cap_value_min)
-                    .then(replacement_min)
-                    .otherwise(nw.col(col))
-                )
-            elif cap_value_max is not None:
-                col_expr = (
-                    nw.when(nw.col(col) > cap_value_max)
-                    .then(replacement_max)
-                    .otherwise(nw.col(col))
-                )
-            else:
-                col_expr = nw.col(col)
-
-            # make sure type is preserved for single row,
-            # e.g. mapping single row to int could convert
-            # from float to int
-            # TODO - look into better ways to achieve this
-            exprs[col] = col_expr.cast(
-                schema[col],
-            ).alias(col)
-
-        X = X.with_columns(**exprs) if exprs else X
-
-        return _return_narwhals_or_native_dataframe(X, return_native)
-
     def to_json(self) -> dict:
         """Return a JSON-serializable representation of the transformer.
 
@@ -617,6 +484,48 @@ class BaseCappingTransformer(BaseNumericTransformer, WeightColumnMixin):
             )
 
         return data
+
+    @beartype
+    def transform(
+        self,
+        X: DataFrame,
+        return_native_override: bool | None = None,
+    ) -> DataFrame:
+        """Apply capping to columns in X.
+
+        If cap_value_max is set, any values above cap_value_max will be set to cap_value_max. If cap_value_min
+        is set any values below cap_value_min will be set to cap_value_min. Only works or numeric columns.
+
+        Parameters
+        ----------
+        X : DataFrame
+            Data to apply capping to.
+
+        return_native_override: Optional[bool]
+            Option to override return_native attr in transformer, useful when calling parent
+            methods
+
+        Returns
+        -------
+        X : DataFrame
+            Transformed input X with min and max capping applied to the specified columns.
+
+        """
+        self.check_is_fitted(["_replacement_values"])
+        if self.quantiles:
+            self.check_is_fitted(["quantile_capping_values"])
+
+        X = _convert_dataframe_to_narwhals(X)
+
+        return_native = self._process_return_native(return_native_override)
+
+        X = super().transform(X, return_native_override=False)
+
+        transform_exprs = self.get_transform_exprs()
+
+        X = X.with_columns(*transform_exprs) if transform_exprs else X
+
+        return _return_narwhals_or_native_dataframe(X, return_native)
 
 
 @register
@@ -791,6 +700,18 @@ class CappingTransformer(BaseCappingTransformer):
         self.is_fitted_ = True
         return self
 
+    def get_transform_exprs(self) -> list[nw.Expr]:
+        """Get transform expressions.
+
+        Returns
+        -------
+        list[nw.Expr]: transform expressions for class
+
+        """
+        return cap_columns(
+            columns=self.columns, column_capping_ranges=self._replacement_values
+        )
+
 
 @register
 class OutOfRangeNullTransformer(BaseCappingTransformer):
@@ -856,12 +777,12 @@ class OutOfRangeNullTransformer(BaseCappingTransformer):
     ┌──────┬──────┬─────┐
     │ a    ┆ b    ┆ c   │
     │ ---  ┆ ---  ┆ --- │
-    │ i64  ┆ i64  ┆ i64 │
+    │ f64  ┆ f64  ┆ i64 │
     ╞══════╪══════╪═════╡
     │ null ┆ null ┆ 1   │
-    │ 15   ┆ 2    ┆ 2   │
-    │ 18   ┆ null ┆ 3   │
-    │ null ┆ 1    ┆ 4   │
+    │ 15.0 ┆ 2.0  ┆ 2   │
+    │ 18.0 ┆ null ┆ 3   │
+    │ null ┆ 1.0  ┆ 4   │
     └──────┴──────┴─────┘
 
     >>> # transformer can also be dumped to json and reinitialised
@@ -891,6 +812,7 @@ class OutOfRangeNullTransformer(BaseCappingTransformer):
         capping_values: dict[str, CappingValues] | None = None,
         quantiles: dict[str, CappingValues] | None = None,
         weights_column: str | None = None,
+        dtype: FloatTypeAnnotated = "Float64",
         **kwargs: bool,
     ) -> None:
         """Initialise class instance.
@@ -918,6 +840,9 @@ class OutOfRangeNullTransformer(BaseCappingTransformer):
             Optional weights column argument that can be used in combination with quantiles. Not used
             if capping_values is supplied. Allows weighted quantiles to be calculated.
 
+        dtype: "Float64" or "Float32"
+            control dtype to return.
+
         **kwargs
             Arbitrary keyword arguments passed onto BaseTransformer.init method.
 
@@ -933,6 +858,8 @@ class OutOfRangeNullTransformer(BaseCappingTransformer):
             self._replacement_values = OutOfRangeNullTransformer.set_replacement_values(
                 self.capping_values,
             )
+
+        self.dtype = dtype
 
     @beartype
     @staticmethod
@@ -1029,3 +956,21 @@ class OutOfRangeNullTransformer(BaseCappingTransformer):
             )
         self.is_fitted_ = True
         return self
+
+    def get_transform_exprs(self) -> list[nw.Expr]:
+        """Get transform expressions.
+
+        Returns
+        -------
+        list[nw.Expr]: transform expressions for class
+
+        """
+        capping_values_for_transform = (
+            self.quantile_capping_values if self.quantiles else self.capping_values
+        )
+
+        return set_out_of_range_to_none(
+            columns=self.columns,
+            column_capping_ranges=capping_values_for_transform,
+            dtype=self.dtype,
+        )

--- a/tubular/capping.py
+++ b/tubular/capping.py
@@ -234,7 +234,6 @@ class BaseCappingTransformer(BaseNumericTransformer, WeightColumnMixin):
 
     @block_from_json
     @beartype
-    @beartype
     def fit(
         self, X: DataFrame, y: Series | LazyFrame | None = None
     ) -> BaseCappingTransformer:

--- a/tubular/capping.py
+++ b/tubular/capping.py
@@ -965,7 +965,9 @@ class OutOfRangeNullTransformer(BaseCappingTransformer):
 
         """
         capping_values_for_transform = (
-            self.quantile_capping_values if self.quantiles else self.capping_values
+            self.quantile_capping_values
+            if self.quantiles is not None
+            else self.capping_values
         )
 
         return set_out_of_range_to_none(

--- a/tubular/functions/capping.py
+++ b/tubular/functions/capping.py
@@ -36,7 +36,7 @@ def cap_columns(
         columns to cap
 
     column_capping_ranges:
-        dict containing per column capping ranges
+        dict containing per column capping ranges, in format {col: [upper_bound, lower_bound]}
 
     Returns
     -------
@@ -66,7 +66,7 @@ def set_out_of_range_to_none(
         columns to cap
 
     column_capping_ranges:
-        dict containing per column capping ranges
+        dict containing per column capping ranges, in format {col: [upper_bound, lower_bound]}
 
     dtype:
         column dtype to return

--- a/tubular/functions/capping.py
+++ b/tubular/functions/capping.py
@@ -55,7 +55,7 @@ def cap_columns(
 @beartype
 def set_out_of_range_to_none(
     columns: list[str],
-    column_capping_ranges: dict[str, CappingValues] | None,
+    column_capping_ranges: dict[str, CappingValues],
     dtype: FloatTypeAnnotated,
 ) -> list[nw.Expr]:
     """Get expression for mapping column values outside of provided range to None.
@@ -101,6 +101,6 @@ def set_out_of_range_to_none(
         .cast(getattr(nw, dtype))
         .alias(col)
         if (column_capping_ranges[col][1] is not None)
-        else nw.col(col).cast(getattr(nw, dtype))
+        else nw.col(col).cast(getattr(nw, dtype)).alias(col)
         for col in columns
     ]

--- a/tubular/functions/capping.py
+++ b/tubular/functions/capping.py
@@ -1,0 +1,106 @@
+"""Contains stateless transforms for capping."""
+
+from typing import Annotated
+
+import narwhals as nw
+from beartype import beartype
+from beartype.vale import Is
+
+from tubular.types import FloatTypeAnnotated, Number
+
+CappingValues = Annotated[
+    list[Number | None],
+    Is[
+        lambda list_arg: (
+            (len(list_arg) == 2)  # noqa: PLR2004
+            & (
+                all(
+                    (isinstance(value, (int, float)) or value is None)
+                    for value in list_arg
+                )
+            )
+        )
+    ],
+]
+
+
+@beartype
+def cap_columns(
+    columns: list[str], column_capping_ranges: dict[str, CappingValues]
+) -> list[nw.Expr]:
+    """Get expression for capping columns within provided ranges.
+
+    Parameters
+    ----------
+    columns:
+        columns to cap
+
+    column_capping_ranges:
+        dict containing per column capping ranges
+
+    Returns
+    -------
+    list[nw.Expr]: expressions for transformation
+
+    """
+    return [
+        nw.col(col).clip(
+            lower_bound=column_capping_ranges[col][0],
+            upper_bound=column_capping_ranges[col][1],
+        )
+        for col in columns
+    ]
+
+
+@beartype
+def set_out_of_range_to_none(
+    columns: list[str],
+    column_capping_ranges: dict[str, CappingValues] | None,
+    dtype: FloatTypeAnnotated,
+) -> list[nw.Expr]:
+    """Get expression for mapping column values outside of provided range to None.
+
+    Parameters
+    ----------
+    columns:
+        columns to cap
+
+    column_capping_ranges:
+        dict containing per column capping ranges
+
+    dtype:
+        column dtype to return
+
+    Returns
+    -------
+    list[nw.Expr]: expressions for transformation
+
+    """
+    return [
+        nw.when(
+            (nw.col(col) >= (column_capping_ranges[col][0]))
+            & (nw.col(col) <= (column_capping_ranges[col][1]))
+        )
+        .then(nw.col(col))
+        .otherwise(None)
+        .cast(getattr(nw, dtype))
+        .alias(col)
+        if (
+            column_capping_ranges[col][0] is not None
+            and column_capping_ranges[col][1] is not None
+        )
+        else nw.when(nw.col(col) < column_capping_ranges[col][0])
+        .then(None)
+        .otherwise(nw.col(col))
+        .cast(getattr(nw, dtype))
+        .alias(col)
+        if (column_capping_ranges[col][0] is not None)
+        else nw.when(nw.col(col) > column_capping_ranges[col][1])
+        .then(None)
+        .otherwise(nw.col(col))
+        .cast(getattr(nw, dtype))
+        .alias(col)
+        if (column_capping_ranges[col][1] is not None)
+        else nw.col(col).cast(getattr(nw, dtype))
+        for col in columns
+    ]


### PR DESCRIPTION
- added get_transform_exprs method to capping transformers
- moved stateless parts of logic to function module
- converted OutOfRangeNullTransformer and CappingTransformer to use different/more specialised transform logic
    - this point relates to this one https://github.com/azukds/tubular/issues/648