### PR TITLE
Update `MeanResponseTransformer.fit()` signature to accept Series or LazyFrame

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -52,7 +52,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-html-pytest-results-${{ matrix.python-version }}
+          name: coverage-html-pytest-results-${{ matrix.python-version }}-sklearn-${{ matrix.sklearn-version }}
           path: htmlcov
 
       - name: Update feature table

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,7 @@ Changed
 - added LowerCaseTransformer and RemoveCharactersTransformer to string module
 - added functions module for stateless transforms
 - removed narwhals private import from nominal module `#725 <https://github.com/azukds/tubular/issues/725>_`
+- bug: fixed MeanResponseTransformer.fit to accept both lazy X and lazy y `#731 <https://github.com/azukds/tubular/pull/731>`_
 
 3.3.0 (30/04/2026)
 ------------------

--- a/tests/nominal/test_MeanResponseTransformer.py
+++ b/tests/nominal/test_MeanResponseTransformer.py
@@ -1529,3 +1529,25 @@ class TestLazyYSupport:
 
         # Mappings should be identical
         assert transformer_lazy.mappings == transformer_eager.mappings
+
+    @pytest.mark.parametrize("library", ["polars"])
+    def test_lazy_x_and_y_consistent_with_eager(self, library):
+        """Test that LazyFrame X and lazy y produce same results as eager inputs."""
+        df_dict = {
+            "a": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            "b": ["x", "y", "x", "y", "x", "y"],
+        }
+        df = dataframe_init_dispatch(df_dict, library)
+        df_lazy = df.lazy()
+        y_lazy = df[["a"]].lazy()
+
+        transformer_lazy = MeanResponseTransformer(columns="b")
+        transformer_eager = MeanResponseTransformer(columns="b")
+
+        # Fit with lazy X and lazy y
+        transformer_lazy.fit(df_lazy, y_lazy)
+
+        # Fit with eager X and eager y
+        transformer_eager.fit(df, df["a"])
+
+        assert transformer_lazy.mappings == transformer_eager.mappings

--- a/tests/nominal/test_MeanResponseTransformer.py
+++ b/tests/nominal/test_MeanResponseTransformer.py
@@ -3,6 +3,7 @@ from itertools import product
 
 import narwhals as nw
 import numpy as np
+import polars as pl
 import pytest
 from beartype.roar import BeartypeCallHintParamViolation
 from sklearn.exceptions import NotFittedError
@@ -1480,3 +1481,51 @@ class TestOtherBaseBehaviour(
         # Now transform should raise NotFittedError
         with pytest.raises(NotFittedError):
             pipeline.transform(df)
+
+
+class TestLazyYSupport:
+    """Tests for lazy y support in MeanResponseTransformer."""
+
+    @pytest.mark.parametrize("library", ["polars"])
+    def test_lazy_y_accepted(self, library):
+        """Test that MeanResponseTransformer accepts LazyFrame for y parameter."""
+        df_dict = {
+            "a": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            "b": ["x", "y", "x", "y", "x", "y"],
+        }
+        df = dataframe_init_dispatch(df_dict, library)
+
+        y_lazy = pl.LazyFrame({"target": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]})
+
+        transformer = MeanResponseTransformer(columns="b")
+
+        # Fit should accept lazy y and not raise an error
+        transformer.fit(df, y_lazy)
+
+        assert transformer.is_fitted_
+        assert transformer.mappings is not None
+        assert "b" in transformer.mappings
+
+    @pytest.mark.parametrize("library", ["polars"])
+    def test_lazy_y_consistent_with_eager_y(self, library):
+        """Test that LazyFrame y produces same results as eager Series y."""
+        df_dict = {
+            "a": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            "b": ["x", "y", "x", "y", "x", "y"],
+        }
+        df = dataframe_init_dispatch(df_dict, library)
+        y_series = df["a"]
+
+        transformer_lazy = MeanResponseTransformer(columns="b")
+        transformer_eager = MeanResponseTransformer(columns="b")
+
+        y_lazy = pl.LazyFrame({"target": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]})
+
+        # Fit with lazy y
+        transformer_lazy.fit(df, y_lazy)
+
+        # Fit with eager y
+        transformer_eager.fit(df, y_series)
+
+        # Mappings should be identical
+        assert transformer_lazy.mappings == transformer_eager.mappings

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -1999,7 +1999,7 @@ class OrdinalEncoderTransformer(
             Data to with catgeorical variable columns to transform and response_column column
             specified when object was initialised.
 
-        y : Series
+        y : Series or LazyFrame
             Response column or target.
 
         Returns

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -17,6 +17,7 @@ from tubular._stats import (
 )
 from tubular._utils import (
     _collect_frame,
+    _collect_series,
     _convert_dataframe_to_narwhals,
     _convert_series_to_narwhals,
     _is_null,
@@ -1003,7 +1004,7 @@ class MeanResponseTransformer(
 
     @block_from_json
     @beartype
-    def fit(self, X: DataFrame, y: Series) -> MeanResponseTransformer:  # noqa:PLR0914, will simplify in future issue
+    def fit(self, X: DataFrame, y: Series | LazyFrame) -> MeanResponseTransformer:  # noqa:PLR0914, will simplify in future issue
         """Identify mapping of categorical levels to mean response values.
 
         If the user specified the weights_column arg in when initialising the transformer
@@ -1050,6 +1051,8 @@ class MeanResponseTransformer(
         """
         X = _convert_dataframe_to_narwhals(X)
         y = _convert_series_to_narwhals(y)
+        # Collect lazy y to enable operations like .unique().to_list()
+        y = _collect_series(y)
 
         BaseTransformer.fit(self, X, y)
 
@@ -1996,7 +1999,7 @@ class OrdinalEncoderTransformer(
             Data to with catgeorical variable columns to transform and response_column column
             specified when object was initialised.
 
-        y : Series or LazyFrame
+        y : Series
             Response column or target.
 
         Returns


### PR DESCRIPTION
I have:
- Updated `MeanResponseTransformer.fit()` signature to accept Series or LazyFrame.
- Added a unit test to test this function.