### PR TITLE
Bugfix/json load

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,13 @@ We use the tags:
 
 Each individual change should have a link to the pull request after the description of the change.
 
+3.6.0 (unreleased)
+------------------
+
+Changed
+^^^^^^^
+- placeholder
+
 3.5.0 (21/05/2026)
 ------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,12 +27,12 @@ We use the tags:
 
 Each individual change should have a link to the pull request after the description of the change.
 
-3.5.0 (unreleased)
+3.5.0 (21/05/2026)
 ------------------
 
 Changed
 ^^^^^^^
-- placeholder
+- bugfix: updated pipeline step name handling in pipeline json dumping/loading to pass when step_name!=transformer_name
 
 3.4.0 (13/05/2026)
 ------------------

--- a/tests/pipeline/test_pipeline_dump_and_load_json.py
+++ b/tests/pipeline/test_pipeline_dump_and_load_json.py
@@ -20,7 +20,7 @@ class TestPipelineDumpAndLoadJson:
         mean_imputer = MeanImputer(columns=["b"])
 
         original_pipeline = Pipeline(
-            [("MedianImputer", median_imputer), ("MeanImputer", mean_imputer)]
+            [("median_imputer", median_imputer), ("mean_imputer", mean_imputer)]
         )
 
         original_pipeline.fit(df, df["a"])
@@ -56,18 +56,18 @@ class TestPipelineDumpAndLoadJson:
         mean_imputer = MeanImputer(columns=["b"])
 
         original_pipeline = Pipeline(
-            [("MedianImputer", median_imputer), ("MeanImputer", mean_imputer)]
+            [("median_imputer", median_imputer), ("mean_imputer", mean_imputer)]
         )
 
         original_pipeline.fit(df, df["a"])
 
         actual_json = dump_pipeline_to_json(original_pipeline)
-        transformers = ["MedianImputer", "MeanImputer"]
+        transformers = ["median_imputer", "mean_imputer"]
         for transformer in transformers:
             # tubular version will differ locally vs in CI, so best to drop from test
             del actual_json[transformer]["tubular_version"]
         expected_json = {
-            "MeanImputer": {
+            "mean_imputer": {
                 "classname": "MeanImputer",
                 "fit": {
                     "is_fitted_": True,
@@ -81,7 +81,7 @@ class TestPipelineDumpAndLoadJson:
                     "weights_column": mean_imputer.weights_column,
                 },
             },
-            "MedianImputer": {
+            "median_imputer": {
                 "classname": "MedianImputer",
                 "fit": {
                     "is_fitted_": True,
@@ -96,7 +96,6 @@ class TestPipelineDumpAndLoadJson:
                 },
             },
         }
-        transformers = ["MedianImputer", "MeanImputer"]
 
         for i, transformer in enumerate(transformers):
             assert actual_json[transformer] == expected_json[transformer], (
@@ -108,7 +107,7 @@ class TestPipelineDumpAndLoadJson:
         bad_transformer = FakeTransformer()
 
         original_pipeline = Pipeline(
-            [("FakeTransformer", bad_transformer), ("MeanImputer", good_transformer)]
+            [("fake_transformer", bad_transformer), ("mean_imputer", good_transformer)]
         )
 
         with pytest.raises(

--- a/tubular/pipeline.py
+++ b/tubular/pipeline.py
@@ -36,12 +36,12 @@ def dump_pipeline_to_json(pipeline: Pipeline) -> dict[str, dict[str, Any]]:
     >>> median_imputer = MedianImputer(columns=["b"])
     >>> mean_imputer = MeanImputer(columns=["b"])
     >>> original_pipeline = Pipeline(
-    ...     [("MedianImputer", median_imputer), ("MeanImputer", mean_imputer)]
+    ...     [("median_imputer", median_imputer), ("mean_imputer", mean_imputer)]
     ... )
     >>> original_pipeline = original_pipeline.fit(df, df["a"])
     >>> pipeline_json = dump_pipeline_to_json(original_pipeline)
     >>> pipeline_json  # doctest: +NORMALIZE_WHITESPACE
-    {'MedianImputer': {'tubular_version':...,
+    {'median_imputer': {'tubular_version':...,
     'classname': 'MedianImputer',
     'init': {'columns': ['b'],
     'copy': False,
@@ -49,7 +49,7 @@ def dump_pipeline_to_json(pipeline: Pipeline) -> dict[str, dict[str, Any]]:
     'return_native': True,
     'weights_column': None},
     'fit': {'is_fitted_': True, 'impute_values_': {'b': 15.0}}},
-    'MeanImputer': {'tubular_version':...,
+    'mean_imputer': {'tubular_version':...,
     'classname': 'MeanImputer',
     'init': {'columns': ['b'],
     'copy': False,

--- a/tubular/pipeline.py
+++ b/tubular/pipeline.py
@@ -92,21 +92,21 @@ def load_pipeline_from_json(pipeline_json: dict[str, dict[str, Any]]) -> Pipelin
     >>> median_imputer = MedianImputer(columns=["b"])
     >>> mean_imputer = MeanImputer(columns=["b"])
     >>> original_pipeline = Pipeline(
-    ...     [("MedianImputer", median_imputer), ("MeanImputer", mean_imputer)]
+    ...     [("median_imputer", median_imputer), ("mean_imputer", mean_imputer)]
     ... )
 
     >>> original_pipeline = original_pipeline.fit(df, df["a"])
     >>> pipeline_json = dump_pipeline_to_json(original_pipeline)
     >>> pipeline = load_pipeline_from_json(pipeline_json)
     >>> pipeline
-    Pipeline(steps=[('MedianImputer', MedianImputer(columns=['b'])),
-                    ('MeanImputer', MeanImputer(columns=['b']))])
+    Pipeline(steps=[('median_imputer', MedianImputer(columns=['b'])),
+                    ('mean_imputer', MeanImputer(columns=['b']))])
 
     ```
 
     """
     steps = [
-        (step_name, CLASS_REGISTRY[step_name].from_json(json_dict))
+        (step_name, CLASS_REGISTRY[json_dict["classname"]].from_json(json_dict))
         for step_name, json_dict in pipeline_json.items()
     ]
 


### PR DESCRIPTION
code was initially setup to expect pipelines like:
[("MeanImputer, MeanImputer(...)), ("MedianImputer", MedianImputer(...))]

but we want other step names to be possible, so have edited for this!