### PR TITLE
bugfix for regex like reference values in StringContainsTransformer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,13 @@ Changed
 ^^^^^^^
 - placeholder
 
+3.7.1 (02/06/2024)
+------------------
+
+Changed
+^^^^^^^
+- bugfix: fix for StringContainsTransformer with regex-like values
+
 3.7.0 (29/05/2026)
 ------------------
 

--- a/tests/strings/test_StringContainsTransformer.py
+++ b/tests/strings/test_StringContainsTransformer.py
@@ -70,6 +70,8 @@ class TestStringContainsTransformerTransform(GenericTransformTests):
             ([None], [None], [None]),
             (["a"], ["b"], [False]),
             (["a", "b", None], ["b", "b", None], [False, True, None]),
+            # test a regex-like reference value
+            (["a"], ["? b"], [False]),
         ],
     )
     def test_output_cases_as_column(
@@ -142,6 +144,8 @@ class TestStringContainsTransformerTransform(GenericTransformTests):
             ([None], "a", [None]),
             (["a"], "b", [False]),
             (["a", "b", None], "b", [False, True, None]),
+            # test a regex-like reference value
+            ([["a"], "? b", [False]]),
         ],
     )
     def test_output_cases_as_value(

--- a/tests/strings/test_StringContainsTransformer.py
+++ b/tests/strings/test_StringContainsTransformer.py
@@ -145,7 +145,7 @@ class TestStringContainsTransformerTransform(GenericTransformTests):
             (["a"], "b", [False]),
             (["a", "b", None], "b", [False, True, None]),
             # test a regex-like reference value
-            ([["a"], "? b", [False]]),
+            (["a"], "? b", [False]),
         ],
     )
     def test_output_cases_as_value(

--- a/tubular/functions/strings.py
+++ b/tubular/functions/strings.py
@@ -58,7 +58,7 @@ def indicate_if_string_columns_contain_reference(
 
     return [
         nw.col(col)
-        .str.contains(reference_for_expr)
+        .str.contains(reference_for_expr, literal=True)
         .alias(f"{col}_contains_{reference}")
         for col in columns
     ]


### PR DESCRIPTION
bugfix for reference columns with regex like values, like "? cat"