### PR TITLE
Bugfix/mre to json

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,7 +27,21 @@ We use the tags:
 
 Each individual change should have a link to the pull request after the description of the change.
 
-3.8.0 (unreleased)
+3.9.0 (unreleased)
+------------------
+
+Changed
+^^^^^^^
+- placeholder
+
+3.8.1 (19/06/2026)
+------------------
+
+Changed
+^^^^^^^
+- bugfix: fix to_json method for MeanResponseTransformer where there are null levels present
+
+3.8.0 (18/06/2026)
 ------------------
 
 Changed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,7 +46,7 @@ Changed
 
 Changed
 ^^^^^^^
-- placeholder
+- added get_transform_exprs methods to capping, aggregations, comparison, dates, misc, numeric transformers and OneHotEncodingTransformer
 
 3.7.1 (02/06/2024)
 ------------------

--- a/tests/nominal/test_MeanResponseTransformer.py
+++ b/tests/nominal/test_MeanResponseTransformer.py
@@ -1482,6 +1482,17 @@ class TestOtherBaseBehaviour(
         with pytest.raises(NotFittedError):
             pipeline.transform(df)
 
+    def test_to_json_works_with_nulls(self):
+        """Test that to_json does not error with null mapping values"""
+
+        x = MeanResponseTransformer(columns="a")
+        x.mappings = {"a": {"a": None, None: 1}}
+        x.return_dtypes = {"a": "String"}
+        x.column_to_encoded_columns = {"a": ["a"]}
+        x.encoded_columns = ["a"]
+
+        x.to_json()
+
 
 class TestLazyYSupport:
     """Tests for lazy y support in MeanResponseTransformer."""

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -748,7 +748,9 @@ class MeanResponseTransformer(
         # make sure mappings dict is sorted for consistent repr
         mappings = {
             key: {
-                value: self.mappings[key][value] for value in sorted(self.mappings[key])
+                # careful with sorted to avoid error for nulls
+                value: self.mappings[key][value]
+                for value in sorted(self.mappings[key], key=lambda x: (x is None, x))
             }
             for key in sorted(self.mappings)
         }


### PR DESCRIPTION
fix for MeanResponseTransformer.to_json method, which was erroring when levels were present in data/mappings