### PR TITLE
bugfix for MRE with learnt integer values, loosened type hints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,13 @@ Changed
 ^^^^^^^
 - placeholder
 
+3.8.2 (19/06/2026)
+------------------
+
+Changed
+^^^^^^^
+- bugfix: loosen typehint on MRE numerically_encode_columns function
+
 3.8.1 (19/06/2026)
 ------------------
 

--- a/tests/nominal/test_MeanResponseTransformer.py
+++ b/tests/nominal/test_MeanResponseTransformer.py
@@ -1446,6 +1446,28 @@ class TestTransform(GenericTransformTests):
             "Mean response values not changed in transform"
         )
 
+    @pytest.mark.parametrize("lazy", [True, False])
+    @pytest.mark.parametrize("from_json", [True, False])
+    @pytest.mark.parametrize("library", ["pandas", "polars"])
+    def test_works_for_integer_learnt_values(self, library, from_json, lazy):
+        """Test that type hints allow integer learnt values."""
+
+        df = create_MeanResponseTransformer_test_df(library=library)
+
+        x = MeanResponseTransformer(columns="b")
+
+        if _check_if_skip_test(x, df, lazy=lazy, from_json=from_json):
+            return
+
+        x.mappings = {"b": {"a": 1}}
+        x.return_dtypes = {"b": "Float64"}
+        x.column_to_encoded_columns = {"b": ["b"]}
+        x.encoded_columns = ["b"]
+        x.unseen_levels_encoding_dict = {"b": 1}
+        x.unseen_level_handling = "median"
+
+        x.transform(_convert_to_lazy(df, lazy=lazy))
+
 
 class TestOtherBaseBehaviour(
     OtherBaseBehaviourTests, EmptyColumnsFitTransformPassTests

--- a/tubular/functions/nominal.py
+++ b/tubular/functions/nominal.py
@@ -40,7 +40,7 @@ def one_hot_encode_columns(
 def numerically_encode_columns(  # noqa: PLR0917, PLR0913
     columns: list[str],
     mappings: dict[str, dict[str, float | int]],
-    unseen_levels_encodings: dict[str, float | np.float32 | np.float64] | None,
+    unseen_levels_encodings: dict[str, float | np.float32 | np.float64 | int] | None,
     unseen_level_handling: bool | str | int | float | None,
     return_dtypes: dict[str, Literal["Float64", "Float32"]],
     column_to_encoded_columns: dict[str, list[str]],


### PR DESCRIPTION
loosened type hint on MRE function to allow for case where learnt values are int