### PR TITLE
Feature/refactor mapping

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,10 @@ Each individual change should have a link to the pull request after the descript
 Changed
 ^^^^^^^
 - bugfix: sort dict attributes to ensure consistent json expressions
+- bugfix: MappingTransformer issues with all null mappings, or columns with null/nan values 
+being mapped to string type.
+- chore: refactored MappingTransformer to pave way for splitting into type based classes with
+`get_transform_exprs` methods.
 
 3.8.4 (25/06/2026)
 ------------------

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -534,6 +534,7 @@ class EmptyMappingsFitTransformPassTests:
         df = minimal_dataframe_lookup[self.transformer_name]
         args = minimal_attribute_dict[self.transformer_name]
         args["mappings"] = {}
+        args["return_dtypes"] = {}
         x = uninitialized_transformers[self.transformer_name](**args)
 
         # skip polars test if not narwhalified

--- a/tests/mapping/test_BaseMappingTransformMixin.py
+++ b/tests/mapping/test_BaseMappingTransformMixin.py
@@ -242,6 +242,7 @@ class TestTransform(GenericTransformTests):
         transformer.mappings = base_mapping_transformer.mappings
         transformer.return_dtypes = base_mapping_transformer.return_dtypes
         transformer.mappings_from_null = base_mapping_transformer.mappings_from_null
+        transformer.columns = base_mapping_transformer.columns
 
         df_transformed = transformer.transform(_convert_to_lazy(df, lazy=lazy))
 
@@ -520,6 +521,7 @@ class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
         x.mappings = {"b": {"a": 1, "b": 2, "c": 3, "d": 4, "e": 5, "f": 6}}
         x.return_dtypes = {"b": "Int8"}
         x.mappings_from_null = {"b": 1}
+        x.columns = ["b"]
 
         output = x.transform(df)
 

--- a/tests/mapping/test_MappingTransformer.py
+++ b/tests/mapping/test_MappingTransformer.py
@@ -1,4 +1,5 @@
 import narwhals as nw
+import numpy as np
 import pytest
 
 import tests.test_data as d
@@ -89,6 +90,88 @@ class TestTransform(BaseMappingTransformerTransformTests, ReturnNativeTests):
         return_dtypes = {"a": "String", "b": "Int8"}
 
         transformer = MappingTransformer(mappings=mapping, return_dtypes=return_dtypes)
+
+        if _check_if_skip_test(transformer, df, lazy=lazy, from_json=False):
+            return
+
+        transformer = _handle_from_json(transformer, from_json)
+
+        df_transformed = transformer.transform(_convert_to_lazy(df, lazy=lazy))
+
+        assert_frame_equal_dispatch(_collect_frame(df_transformed, lazy=lazy), expected)
+
+        df = nw.from_native(df)
+        expected = nw.from_native(expected)
+
+        # also check single rows
+        for i in range(len(df)):
+            df_transformed_row = transformer.transform(
+                _convert_to_lazy(df[[i]].to_native(), lazy=lazy)
+            )
+            df_expected_row = expected[[i]].to_native()
+
+            assert_frame_equal_dispatch(
+                _collect_frame(df_transformed_row, lazy=lazy),
+                df_expected_row,
+            )
+
+    @pytest.mark.parametrize("lazy", [True, False])
+    @pytest.mark.parametrize("from_json", [True, False])
+    @pytest.mark.parametrize("library", ["pandas", "polars"])
+    def test_expected_output_null_type(self, library, from_json, lazy):
+        """Test that transform is giving the expected output when type of mappings is null."""
+
+        df_dict = {"a": [np.nan, None, 1]}
+        expected_df_dict = {"a": [None, None, 1]}
+        df = dataframe_init_dispatch(dataframe_dict=df_dict, library=library)
+        expected = dataframe_init_dispatch(
+            dataframe_dict=expected_df_dict, library=library
+        )
+
+        mapping = {"a": {np.nan: None}}
+
+        transformer = MappingTransformer(mappings=mapping)
+
+        if _check_if_skip_test(transformer, df, lazy=lazy, from_json=False):
+            return
+
+        transformer = _handle_from_json(transformer, from_json)
+
+        df_transformed = transformer.transform(_convert_to_lazy(df, lazy=lazy))
+
+        assert_frame_equal_dispatch(_collect_frame(df_transformed, lazy=lazy), expected)
+
+        df = nw.from_native(df)
+        expected = nw.from_native(expected)
+
+        # also check single rows
+        for i in range(len(df)):
+            df_transformed_row = transformer.transform(
+                _convert_to_lazy(df[[i]].to_native(), lazy=lazy)
+            )
+            df_expected_row = expected[[i]].to_native()
+
+            assert_frame_equal_dispatch(
+                _collect_frame(df_transformed_row, lazy=lazy),
+                df_expected_row,
+            )
+
+    @pytest.mark.parametrize("lazy", [True, False])
+    @pytest.mark.parametrize("from_json", [True, False])
+    @pytest.mark.parametrize("library", ["pandas", "polars"])
+    def test_null_handling_for_str_return_type(self, library, from_json, lazy):
+        """Test that transform is giving the expected output - for string type with nulls."""
+
+        df_dict = {"a": [np.nan, None, 1]}
+        expected_df_dict = {"a": [None, None, "b"]}
+        df = dataframe_init_dispatch(dataframe_dict=df_dict, library=library)
+        expected = dataframe_init_dispatch(
+            dataframe_dict=expected_df_dict, library=library
+        )
+
+        mapping = {"a": {1: "b"}}
+
+        transformer = MappingTransformer(mappings=mapping)
 
         if _check_if_skip_test(transformer, df, lazy=lazy, from_json=False):
             return

--- a/tests/mapping/test_MappingTransformer.py
+++ b/tests/mapping/test_MappingTransformer.py
@@ -421,6 +421,33 @@ class TestTransform(BaseMappingTransformerTransformTests, ReturnNativeTests):
 
         assert_frame_equal_dispatch(expected, _collect_frame(df_transformed, lazy=lazy))
 
+    @pytest.mark.parametrize("lazy", [True, False])
+    @pytest.mark.parametrize("from_json", [True, False])
+    @pytest.mark.parametrize("library", ["pandas", "polars"])
+    def test_error_for_bad_type(self, library, from_json, lazy):
+        """Test expected error is raised for unexpected type."""
+        df_dict = {"a": ["01/02/2020", "20/03/1990"]}
+        df = dataframe_init_dispatch(dataframe_dict=df_dict, library=library)
+        df = nw.from_native(df)
+        df = df.with_columns(nw.col("a").str.to_datetime(format="%d/%m/%Y")).to_native()
+
+        mapping = {"a": {"a": "aaa"}}
+        return_dtypes = {"a": "Categorical"}
+
+        transformer = MappingTransformer(mappings=mapping, return_dtypes=return_dtypes)
+
+        if _check_if_skip_test(transformer, df, lazy=lazy, from_json=False):
+            return
+
+        transformer = _handle_from_json(transformer, from_json)
+
+        msg = r"MappingTransformer: The following columns have types which are not covered by the existing mapping logic \['a'\]"
+        with pytest.raises(
+            RuntimeError,
+            match=msg,
+        ):
+            transformer.transform(_convert_to_lazy(df, lazy=lazy))
+
 
 class TestOtherBaseBehaviour(
     OtherBaseBehaviourTests,

--- a/tubular/functions/mapping.py
+++ b/tubular/functions/mapping.py
@@ -1,0 +1,270 @@
+"""Stateless mapping transforms."""
+
+from typing import Any, Literal
+
+import narwhals as nw
+from beartype import beartype
+
+RETURN_DTYPES = Literal[
+    "String",
+    "Categorical",
+    "Boolean",
+    "Int8",
+    "Int16",
+    "Int32",
+    "Int64",
+    "Float32",
+    "Float64",
+]
+
+
+@beartype
+def _get_mapping_expr(
+    col: str,
+    mappings: dict[str, dict[Any, Any]],
+    mappings_from_null: dict[str, Any],
+    pre_mapping_expr: nw.Expr | None = None,
+) -> nw.Expr:
+    """Get expression for mapping column.
+
+    Parameters
+    ----------
+    col:
+        column to map
+
+    mappings :
+        Dictionary of mappings for each column individually. The dict passed to mappings in
+    init is set to the mappings attribute.
+
+    mappings_from_null:
+        dict storing what null values will be mapped to. Generally best to use an imputer,
+    but this functionality is useful for inverting pipelines.
+
+    pre_mapping_expr:
+        expression containing any transforms necessary prior to mapping logic.
+
+    Returns
+    -------
+    list[nw.Expr]: expressions for transformation
+
+    """
+    if pre_mapping_expr is None:
+        pre_mapping_expr = nw.col(col)
+
+    mappable_condition = nw.col(col).is_in(mappings[col])
+
+    mapping_expr = (
+        nw.when(mappable_condition)
+        .then(
+            # default here allows replace_strict to work, but the nulls are replaced
+            # in the otherwise section anyway
+            pre_mapping_expr.replace_strict(mappings[col], default=None)
+        )
+        .otherwise(pre_mapping_expr)
+    )
+
+    return (
+        mapping_expr.fill_null(mappings_from_null[col])
+        if mappings_from_null[col] is not None
+        else mapping_expr
+    )
+
+
+@beartype
+def map_number_to_string(
+    cols: list[str],
+    mappings: dict[str, dict[Any, Any]],
+    mappings_from_null: dict[str, Any],
+) -> list[nw.Expr]:
+    """Get expression for mapping numeric columns into string type columns.
+
+    Parameters
+    ----------
+    cols:
+        columns to map
+
+    mappings :
+        Dictionary of mappings for each column individually. The dict passed to mappings in
+    init is set to the mappings attribute.
+
+    mappings_from_null:
+        dict storing what null values will be mapped to. Generally best to use an imputer,
+    but this functionality is useful for inverting pipelines.
+
+    Returns
+    -------
+    list[nw.Expr]: expressions for transformation
+
+    """
+    return [
+        _get_mapping_expr(
+            col,
+            pre_mapping_expr=nw.col(col).fill_nan(None),
+            mappings=mappings,
+            mappings_from_null=mappings_from_null,
+        )
+        for col in cols
+    ]
+
+
+@beartype
+def map_generic_to_bool(
+    cols: list[str],
+    library: Literal["pandas", "polars"],
+    mappings: dict[str, dict[Any, Any]],
+    mappings_from_null: dict[str, Any],
+) -> list[nw.Expr]:
+    """Get expression for mapping columns into boolean type columns.
+
+    Parameters
+    ----------
+    cols:
+        columns to map
+
+    library:
+        pandas or polars.
+
+    mappings :
+        Dictionary of mappings for each column individually. The dict passed to mappings in
+    init is set to the mappings attribute.
+
+    mappings_from_null:
+        dict storing what null values will be mapped to. Generally best to use an imputer,
+    but this functionality is useful for inverting pipelines.
+
+    Returns
+    -------
+    list[nw.Expr]: expressions for transformation
+
+    """
+    return [
+        _get_mapping_expr(
+            col,
+            mappings=mappings,
+            mappings_from_null=mappings_from_null,
+        ).cast(nw.Boolean)
+        if library == "polars"
+        else _get_mapping_expr(
+            col,
+            mappings=mappings,
+            mappings_from_null=mappings_from_null,
+        )
+        for col in cols
+    ]
+
+
+@beartype
+def map_generic_to_str(
+    cols: list[str],
+    mappings: dict[str, dict[Any, Any]],
+    mappings_from_null: dict[str, Any],
+) -> list[nw.Expr]:
+    """Get expression for mapping non-numeric columns into string type columns.
+
+    Parameters
+    ----------
+    cols:
+        columns to map
+
+    mappings :
+        Dictionary of mappings for each column individually. The dict passed to mappings in
+    init is set to the mappings attribute.
+
+    mappings_from_null:
+        dict storing what null values will be mapped to. Generally best to use an imputer,
+    but this functionality is useful for inverting pipelines.
+
+    Returns
+    -------
+    list[nw.Expr]: expressions for transformation
+
+    """
+    return [
+        _get_mapping_expr(
+            col,
+            mappings=mappings,
+            mappings_from_null=mappings_from_null,
+        ).cast(nw.String)
+        for col in cols
+    ]
+
+
+@beartype
+def map_generic_to_number(
+    cols: list[str],
+    return_dtypes: dict[str, RETURN_DTYPES],
+    mappings: dict[str, dict[Any, Any]],
+    mappings_from_null: dict[str, Any],
+) -> list[nw.Expr]:
+    """Get expression for mapping generic type columns into numeric type columns.
+
+    Parameters
+    ----------
+    cols:
+        columns to map
+
+    return_dtypes:
+        Dictionary of col:dtype for returned columns
+
+    mappings :
+        Dictionary of mappings for each column individually. The dict passed to mappings in
+    init is set to the mappings attribute.
+
+    mappings_from_null:
+        dict storing what null values will be mapped to. Generally best to use an imputer,
+    but this functionality is useful for inverting pipelines.
+
+    Returns
+    -------
+    list[nw.Expr]: expressions for transformation
+
+    """
+    return [
+        _get_mapping_expr(
+            col,
+            mappings=mappings,
+            mappings_from_null=mappings_from_null,
+        ).cast(getattr(nw, return_dtypes[col]))
+        for col in cols
+    ]
+
+
+@beartype
+def map_generic_to_categorical(
+    cols: list[str],
+    return_dtypes: dict[str, RETURN_DTYPES],
+    mappings: dict[str, dict[Any, Any]],
+    mappings_from_null: dict[str, Any],
+) -> list[nw.Expr]:
+    """Get expression for mapping generic type columns into categorical type columns.
+
+    Parameters
+    ----------
+    cols:
+        columns to map
+
+    return_dtypes:
+        Dictionary of col:dtype for returned columns
+
+    mappings :
+        Dictionary of mappings for each column individually. The dict passed to mappings in
+    init is set to the mappings attribute.
+
+    mappings_from_null:
+        dict storing what null values will be mapped to. Generally best to use an imputer,
+    but this functionality is useful for inverting pipelines.
+
+    Returns
+    -------
+    list[nw.Expr]: expressions for transformation
+
+    """
+    return [
+        _get_mapping_expr(
+            col,
+            pre_mapping_expr=nw.col(col).cast(nw.String),
+            mappings=mappings,
+            mappings_from_null=mappings_from_null,
+        ).cast(getattr(nw, return_dtypes[col]))
+        for col in cols
+    ]

--- a/tubular/functions/mapping.py
+++ b/tubular/functions/mapping.py
@@ -17,6 +17,19 @@ RETURN_DTYPES = Literal[
     "Float64",
 ]
 
+NUMERIC_TYPES = Literal[
+    "UInt8",
+    "UInt16",
+    "UInt32",
+    "UInt64",
+    "Int8",
+    "Int16",
+    "Int32",
+    "Int64",
+    "Float32",
+    "Float64",
+]
+
 
 @beartype
 def _get_mapping_expr(
@@ -192,7 +205,7 @@ def map_generic_to_str(
 @beartype
 def map_generic_to_number(
     cols: list[str],
-    return_dtypes: dict[str, RETURN_DTYPES],
+    return_dtypes: dict[str, NUMERIC_TYPES],
     mappings: dict[str, dict[Any, Any]],
     mappings_from_null: dict[str, Any],
 ) -> list[nw.Expr]:
@@ -230,7 +243,7 @@ def map_generic_to_number(
 
 
 @beartype
-def map_generic_to_categorical(
+def map_categorical_to_generic(
     cols: list[str],
     return_dtypes: dict[str, RETURN_DTYPES],
     mappings: dict[str, dict[Any, Any]],

--- a/tubular/mapping.py
+++ b/tubular/mapping.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import warnings
 from collections import OrderedDict
-from typing import Any, Literal
+from typing import Any
 
 import narwhals as nw
 import numpy as np
@@ -20,7 +21,15 @@ from tubular._utils import (
     block_from_json,
 )
 from tubular.base import BaseTransformer, register
-from tubular.types import DataFrame
+from tubular.functions.mapping import (
+    RETURN_DTYPES,
+    map_generic_to_bool,
+    map_generic_to_categorical,
+    map_generic_to_number,
+    map_generic_to_str,
+    map_number_to_string,
+)
+from tubular.types import DataFrame, NumericTypes
 
 
 @register
@@ -77,19 +86,6 @@ class BaseMappingTransformer(BaseTransformer):
     FITS = False
 
     jsonable = True
-
-    RETURN_DTYPES = Literal[
-        "String",
-        "Object",
-        "Categorical",
-        "Boolean",
-        "Int8",
-        "Int16",
-        "Int32",
-        "Int64",
-        "Float32",
-        "Float64",
-    ]
 
     @beartype
     def __init__(
@@ -148,7 +144,7 @@ class BaseMappingTransformer(BaseTransformer):
             provided_return_dtype_keys = set()
 
         for col in set(mappings.keys()).difference(provided_return_dtype_keys):
-            return_dtypes[col] = self._infer_return_type(mappings, col)
+            return_dtypes[col] = self._infer_return_type(col)
 
         self.return_dtypes = return_dtypes
 
@@ -191,9 +187,8 @@ class BaseMappingTransformer(BaseTransformer):
 
         return json_dict
 
-    @staticmethod
     def _infer_return_type(
-        mappings: dict[str, dict[str, str | float | int]],
+        self,
         col: str,
     ) -> str:
         """Infer return_dtypes from provided mappings.
@@ -206,13 +201,22 @@ class BaseMappingTransformer(BaseTransformer):
         Examples
         --------
         ```pycon
-        >>> BaseMappingTransformer._infer_return_type({"a": {"Y": 1, "N": 0}}, col="a")
+        >>> BaseMappingTransformer(mappings={"a": {"Y": 1, "N": 0}})._infer_return_type(col="a")
         'Int64'
 
         ```
 
         """
-        return str(pl.Series(mappings[col].values()).dtype)
+        dtype = str(pl.Series(self.mappings[col].values()).dtype)
+
+        if dtype == "Null":
+            dtype = "Float64"
+            warnings.warn(
+                f"{self.classname()}: Mappings with Null dtype have been provided, narwhals does not expose this dtype, so type will be assumed as Float64. Alternate types can be set using the return_dtypes argument.",
+                stacklevel=2,
+            )
+
+        return dtype
 
     def transform(
         self,
@@ -309,7 +313,7 @@ class BaseMappingTransformMixin(BaseTransformer):
     jsonable = False
 
     @beartype
-    def transform(
+    def transform(  # noqa: PLR0914, will fix in future refactor
         self,
         X: DataFrame,
         return_native_override: bool | None = None,
@@ -346,54 +350,98 @@ class BaseMappingTransformMixin(BaseTransformer):
 
         X = super().transform(X, return_native_override=False)
 
-        mappable_conditions = {
-            col: nw.col(col).is_in(self.mappings[col]) for col in self.mappings
-        }
-
-        # if the column is categorical, narwhals struggles to infer a type
-        # during the when/then logic, so we need to tell polars to use string
-        # as a common type.
-        # types are then corrected before returning at the end
         schema = X.collect_schema()
-        mapping_exprs = {
-            col: nw.col(col).cast(nw.String)
-            if schema[col] in {nw.Categorical, nw.Enum}
-            else nw.col(col)
-            for col in self.mappings
-        }
 
-        mapping_exprs = {
-            col: nw.when(mappable_conditions[col])
-            .then(
-                # default here allows replace_strict to work, but the nulls are replaced
-                # in the otherwise section anyway
-                mapping_exprs[col].replace_strict(self.mappings[col], default=None)
+        cols_mapped_from_or_to_categorical = [
+            col
+            for col in self.return_dtypes
+            if (
+                (self.return_dtypes[col] == "Categorical")
+                or (isinstance(schema[col], (nw.Categorical, nw.Enum)))
             )
-            .otherwise(mapping_exprs[col])
-            for col in self.mappings
-        }
+        ]
+        remaining_cols = [
+            col
+            for col in self.return_dtypes
+            if col not in cols_mapped_from_or_to_categorical
+        ]
+        cols_mapped_num_to_str = [
+            col
+            for col in remaining_cols
+            if (
+                self.return_dtypes[col] == "String"
+                and isinstance(schema[col], tuple(NumericTypes))
+            )
+        ]
+        cols_mapped_generic_to_str = [
+            col
+            for col in remaining_cols
+            if (
+                self.return_dtypes[col] == "String"
+                and (col not in cols_mapped_num_to_str)
+            )
+        ]
+        cols_mapped_generic_to_bool = [
+            col for col in remaining_cols if self.return_dtypes[col] == "Boolean"
+        ]
+        cols_mapped_generic_to_number = [
+            col
+            for col in remaining_cols
+            if self.return_dtypes[col]
+            in {
+                "Int8",
+                "Int16",
+                "Int32",
+                "Int64",
+                "Float32",
+                "Float64",
+            }
+        ]
 
-        # finally, handle mappings from null (imputations)
-        mapping_exprs = {
-            col: (mapping_exprs[col].fill_null(self.mappings_from_null[col]))
-            if self.mappings_from_null[col] is not None
-            else mapping_exprs[col]
-            for col in mapping_exprs
-        }
+        num_to_str_mapping_exprs = map_number_to_string(
+            cols=cols_mapped_num_to_str,
+            mappings=self.mappings,
+            mappings_from_null=self.mappings_from_null,
+        )
 
-        # handle casting for non-bool return types
-        # (bool has special handling at end)
-        mapping_exprs = {
-            col: mapping_exprs[col].cast(getattr(nw, self.return_dtypes[col]))
-            # pandas bool types need special handling
-            if not (self.return_dtypes[col] == "Boolean" and backend == "pandas")
-            else mapping_exprs[col]
-            for col in mapping_exprs
-        }
+        generic_to_str_mapping_exprs = map_generic_to_str(
+            cols_mapped_generic_to_str,
+            mappings=self.mappings,
+            mappings_from_null=self.mappings_from_null,
+        )
+
+        generic_to_number_mapping_exprs = map_generic_to_number(
+            cols=cols_mapped_generic_to_number,
+            return_dtypes=self.return_dtypes,
+            mappings=self.mappings,
+            mappings_from_null=self.mappings_from_null,
+        )
+
+        categorical_mapping_exprs = map_generic_to_categorical(
+            cols=cols_mapped_from_or_to_categorical,
+            return_dtypes=self.return_dtypes,
+            mappings=self.mappings,
+            mappings_from_null=self.mappings_from_null,
+        )
+
+        generic_to_bool_mapping_exprs = map_generic_to_bool(
+            cols=cols_mapped_generic_to_bool,
+            library=backend,
+            mappings=self.mappings,
+            mappings_from_null=self.mappings_from_null,
+        )
+
+        mapping_exprs = [
+            *num_to_str_mapping_exprs,
+            *generic_to_bool_mapping_exprs,
+            *generic_to_str_mapping_exprs,
+            *categorical_mapping_exprs,
+            *generic_to_number_mapping_exprs,
+        ]
 
         X = (
             X.with_columns(
-                **mapping_exprs,
+                *mapping_exprs,
             )
             if mapping_exprs
             else X

--- a/tubular/mapping.py
+++ b/tubular/mapping.py
@@ -23,8 +23,8 @@ from tubular._utils import (
 from tubular.base import BaseTransformer, register
 from tubular.functions.mapping import (
     RETURN_DTYPES,
+    map_categorical_to_generic,
     map_generic_to_bool,
-    map_generic_to_categorical,
     map_generic_to_number,
     map_generic_to_str,
     map_number_to_string,
@@ -334,6 +334,11 @@ class BaseMappingTransformMixin(BaseTransformer):
         X : DataFrame
             Transformed input X with levels mapped according to mappings dict.
 
+        Raises
+        ------
+        RuntimeError:
+            If columns to be mapped in X have unsupported type.
+
         #  not currently including doctest for this, as is not intended to be used
         #  independently (should be inherited as a mixin)
 
@@ -352,19 +357,18 @@ class BaseMappingTransformMixin(BaseTransformer):
 
         schema = X.collect_schema()
 
-        cols_mapped_from_or_to_categorical = [
+        remaining_cols = self.columns
+
+        cols_mapped_from_categorical = [
             col
             for col in self.return_dtypes
-            if (
-                (self.return_dtypes[col] == "Categorical")
-                or (isinstance(schema[col], (nw.Categorical, nw.Enum)))
-            )
+            if (isinstance(schema[col], (nw.Categorical, nw.Enum)))
         ]
-        remaining_cols = [
-            col
-            for col in self.return_dtypes
-            if col not in cols_mapped_from_or_to_categorical
-        ]
+
+        remaining_cols = list(
+            set(remaining_cols).difference(set(cols_mapped_from_categorical))
+        )
+
         cols_mapped_num_to_str = [
             col
             for col in remaining_cols
@@ -373,17 +377,27 @@ class BaseMappingTransformMixin(BaseTransformer):
                 and isinstance(schema[col], tuple(NumericTypes))
             )
         ]
+
+        remaining_cols = list(
+            set(remaining_cols).difference(set(cols_mapped_num_to_str))
+        )
+
         cols_mapped_generic_to_str = [
-            col
-            for col in remaining_cols
-            if (
-                self.return_dtypes[col] == "String"
-                and (col not in cols_mapped_num_to_str)
-            )
+            col for col in remaining_cols if (self.return_dtypes[col] == "String")
         ]
+
+        remaining_cols = list(
+            set(remaining_cols).difference(set(cols_mapped_generic_to_str))
+        )
+
         cols_mapped_generic_to_bool = [
             col for col in remaining_cols if self.return_dtypes[col] == "Boolean"
         ]
+
+        remaining_cols = list(
+            set(remaining_cols).difference(set(cols_mapped_generic_to_bool))
+        )
+
         cols_mapped_generic_to_number = [
             col
             for col in remaining_cols
@@ -397,6 +411,14 @@ class BaseMappingTransformMixin(BaseTransformer):
                 "Float64",
             }
         ]
+
+        remaining_cols = list(
+            set(remaining_cols).difference(set(cols_mapped_generic_to_number))
+        )
+
+        if len(remaining_cols) != 0:
+            msg = f"{self.classname()}: The following columns have types which are not covered by the existing mapping logic {remaining_cols}"
+            raise (RuntimeError(msg))
 
         num_to_str_mapping_exprs = map_number_to_string(
             cols=cols_mapped_num_to_str,
@@ -412,13 +434,17 @@ class BaseMappingTransformMixin(BaseTransformer):
 
         generic_to_number_mapping_exprs = map_generic_to_number(
             cols=cols_mapped_generic_to_number,
-            return_dtypes=self.return_dtypes,
+            return_dtypes={
+                key: value
+                for key, value in self.return_dtypes.items()
+                if key in cols_mapped_generic_to_number
+            },
             mappings=self.mappings,
             mappings_from_null=self.mappings_from_null,
         )
 
-        categorical_mapping_exprs = map_generic_to_categorical(
-            cols=cols_mapped_from_or_to_categorical,
+        categorical_mapping_exprs = map_categorical_to_generic(
+            cols=cols_mapped_from_categorical,
             return_dtypes=self.return_dtypes,
             mappings=self.mappings,
             mappings_from_null=self.mappings_from_null,


### PR DESCRIPTION
refactor in order to fix a couple of bugs with mappingtransformers null handling:

- all null mappings were erroring due to type being inferred as Null, which does not exist in narwhals
- mapping to String type columns where nulls/nans were present was causing issues like NaN->"nan", or erroring due to NaN values being incompatible with string type

Was easiest to fix by splitting out logic by type, this was on my todo list anyway and is a stepping stone towards having 'get_transform_exprs' methods for this module