### PR TITLE
Fix schema type membership checks and extend GroupRareLevelsTransformer to accept Enum columns

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ Each individual change should have a link to the pull request after the descript
 
 Changed
 ^^^^^^^
+- bugfix: use isinstance for schema type membership checks and allow enum columns for GroupRareLevelsTransformer
 - bugfix: sort dict attributes to ensure consistent json expressions
 - chore: added TRY ruleset to ruff config `#510 <https://github.com/azukds/tubular/issues/510>_`
 

--- a/tubular/mapping.py
+++ b/tubular/mapping.py
@@ -357,7 +357,7 @@ class BaseMappingTransformMixin(BaseTransformer):
         schema = X.collect_schema()
         mapping_exprs = {
             col: nw.col(col).cast(nw.String)
-            if schema[col] in {nw.Categorical, nw.Enum}
+            if isinstance(schema[col], (nw.Categorical, nw.Enum))
             else nw.col(col)
             for col in self.mappings
         }

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -281,7 +281,7 @@ class GroupRareLevelsTransformer(BaseTransformer, WeightColumnMixin):
         str_like_columns = [
             col
             for col in self.columns
-            if schema[col] in {nw.String, nw.Categorical, nw.Object}
+            if isinstance(schema[col], (nw.String, nw.Categorical, nw.Object))
         ]
 
         non_str_like_columns = set(self.columns).difference(
@@ -488,7 +488,7 @@ class GroupRareLevelsTransformer(BaseTransformer, WeightColumnMixin):
                 nw.col(col).cast(
                     nw.String,
                 )
-                if schema[col] in {nw.Categorical, nw.Enum}
+                if isinstance(schema[col], (nw.Categorical, nw.Enum))
                 else nw.col(col)
             )
 
@@ -502,7 +502,7 @@ class GroupRareLevelsTransformer(BaseTransformer, WeightColumnMixin):
                 transform_expression.cast(
                     nw.Enum(self.non_rare_levels[col] + [self.rare_level_name]),
                 )
-                if (schema[col] in {nw.Categorical, nw.Enum})
+                if isinstance(schema[col], (nw.Categorical, nw.Enum))
                 else transform_expression
             )
 

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -241,12 +241,13 @@ class GroupRareLevelsTransformer(BaseTransformer, WeightColumnMixin):
 
         Parameters
         ----------
-        schema: nw.Schema
-            schema of input data
+        schema : nw.Schema
+            Schema of input data.
 
         Raises
         ------
-        TypeError: if columns are not str-like
+        TypeError
+            If columns are not str-like.
 
         Examples
         --------
@@ -281,17 +282,16 @@ class GroupRareLevelsTransformer(BaseTransformer, WeightColumnMixin):
         str_like_columns = [
             col
             for col in self.columns
-            if isinstance(schema[col], (nw.String, nw.Categorical, nw.Object))
+            if isinstance(schema[col], (nw.String, nw.Categorical, nw.Enum, nw.Object))
         ]
 
-        non_str_like_columns = set(self.columns).difference(
-            set(
-                str_like_columns,
-            ),
-        )
+        non_str_like_columns = set(self.columns).difference(set(str_like_columns))
 
         if len(non_str_like_columns) != 0:
-            msg = f"{self.classname()}: transformer must run on str-like columns, but got non str-like {non_str_like_columns}"
+            msg = (
+                f"{self.classname()}: transformer must run on str-like columns, but "
+                f"got non str-like {non_str_like_columns}"
+            )
             raise TypeError(msg)
 
     @block_from_json


### PR DESCRIPTION
Due to the implementation from narwhals of the `Enum` dtype, a type check written like: `schema[col] in {nw.Enum}` would return `False`, even when `col` is actually of Enum type.

This is because when doing a set lookup Python uses the hash, however `hash(nw.Enum(["a"])) != hash(nw.Enum)`, leading to Python not finding the Enum dtype in the set.

This replaces all affected areas with usage of `isinstance` instead. It also extends the definition of "string-like" columns in `GroupRareLevelsTransformer` to include Enum-type columns, as the `transform` method is written to expect.