### PR TITLE
Fix numeric mapping keys after JSON round trips

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ Each individual change should have a link to the pull request after the descript
 -------------------
 Changed
 ^^^^^^^
+- bugfix: preserve numeric mapping keys across JSON round trips `#757 <https://github.com/azukds/tubular/issues/757>`_
 - added get_transform_exprs methods to NullIndicator transformer `#750 <https://github.com/azukds/tubular/issues/750>_`
 - added get_transform_exprs methods to BaseImputer `#751 <https://github.com/azukds/tubular/issues/751>_`
 - placeholder

--- a/tests/mapping/test_MappingTransformer.py
+++ b/tests/mapping/test_MappingTransformer.py
@@ -1,3 +1,5 @@
+import json
+
 import narwhals as nw
 import pytest
 
@@ -71,6 +73,18 @@ class TestTransform(BaseMappingTransformerTransformTests, ReturnNativeTests):
     @classmethod
     def setup_class(cls):
         cls.transformer_name = "MappingTransformer"
+
+    def test_json_round_trip_preserves_numeric_mapping_keys(self):
+        """Test numeric mapping keys survive a real JSON round trip."""
+        transformer = MappingTransformer(
+            mappings={"a": {-999: 0}},
+            return_dtypes={"a": "Int64"},
+        )
+
+        serialized = json.loads(json.dumps(transformer.to_json()))
+        restored = MappingTransformer.from_json(serialized)
+
+        assert restored.mappings == {"a": {-999: 0}}
 
     @pytest.mark.parametrize("lazy", [True, False])
     @pytest.mark.parametrize("from_json", [True, False])

--- a/tubular/mapping.py
+++ b/tubular/mapping.py
@@ -171,7 +171,7 @@ class BaseMappingTransformer(BaseTransformer):
         >>> mapping_transformer = BaseMappingTransformer(mappings={"a": {"x": 1}})
 
         >>> mapping_transformer.to_json()
-        {'tubular_version': ..., 'classname': 'BaseMappingTransformer', 'init': {'copy': False, 'verbose': False, 'return_native': True, 'mappings': {'a': {'x': 1}}, 'return_dtypes': {'a': 'Int64'}}, 'fit': {'is_fitted_': True}}
+        {'tubular_version': ..., 'classname': 'BaseMappingTransformer', 'init': {'copy': False, 'verbose': False, 'return_native': True, 'mappings': {'a': [('x', 1)]}, 'return_dtypes': {'a': 'Int64'}}, 'fit': {'is_fitted_': True}}
 
         ```
 
@@ -186,10 +186,41 @@ class BaseMappingTransformer(BaseTransformer):
 
         return_dtypes = _sort_dict(self.return_dtypes)
 
-        json_dict["init"]["mappings"] = mappings
+        json_dict["init"]["mappings"] = {
+            column: list(column_mappings.items())
+            for column, column_mappings in mappings.items()
+        }
         json_dict["init"]["return_dtypes"] = return_dtypes
 
         return json_dict
+
+    @classmethod
+    def from_json(
+        cls,  # pyright: ignore[reportGeneralTypeIssues]
+        json: dict[str, Any],
+    ) -> BaseTransformer:
+        """Rebuild a mapping transformer from its JSON-compatible dictionary.
+
+        Returns
+        -------
+        BaseTransformer
+            Reconstructed mapping transformer ready for transform.
+
+        """
+        serialized_mappings = json["init"]["mappings"]
+        if all(isinstance(items, list) for items in serialized_mappings.values()):
+            json = {
+                **json,
+                "init": {
+                    **json["init"],
+                    "mappings": {
+                        column: dict(items)
+                        for column, items in serialized_mappings.items()
+                    },
+                },
+            }
+
+        return super().from_json(json)
 
     @staticmethod
     def _infer_return_type(
@@ -485,7 +516,7 @@ class MappingTransformer(BaseMappingTransformer, BaseMappingTransformMixin):
     >>> # transformer can also be dumped to json and reinitialised
     >>> json_dump = transformer.to_json()
     >>> json_dump
-    {'tubular_version': ..., 'classname': 'MappingTransformer', 'init': {'copy': False, 'verbose': False, 'return_native': True, 'mappings': {'a': {'N': 0, 'Y': 1}}, 'return_dtypes': {'a': 'Int8'}}, 'fit': {'is_fitted_': True}}
+    {'tubular_version': ..., 'classname': 'MappingTransformer', 'init': {'copy': False, 'verbose': False, 'return_native': True, 'mappings': {'a': [('N', 0), ('Y', 1)]}, 'return_dtypes': {'a': 'Int8'}}, 'fit': {'is_fitted_': True}}
 
     >>> MappingTransformer.from_json(json_dump)
     MappingTransformer(mappings={'a': {'N': 0, 'Y': 1}},

--- a/tubular/mapping.py
+++ b/tubular/mapping.py
@@ -171,7 +171,7 @@ class BaseMappingTransformer(BaseTransformer):
         >>> mapping_transformer = BaseMappingTransformer(mappings={"a": {"x": 1}})
 
         >>> mapping_transformer.to_json()
-        {'tubular_version': ..., 'classname': 'BaseMappingTransformer', 'init': {'copy': False, 'verbose': False, 'return_native': True, 'mappings': {'a': [('x', 1)]}, 'return_dtypes': {'a': 'Int64'}}, 'fit': {'is_fitted_': True}}
+        {'tubular_version': ..., 'classname': 'BaseMappingTransformer', 'init': {'copy': False, 'verbose': False, 'return_native': True, 'mappings': {'a': [['x', 1]]}, 'return_dtypes': {'a': 'Int64'}}, 'fit': {'is_fitted_': True}}
 
         ```
 
@@ -187,7 +187,7 @@ class BaseMappingTransformer(BaseTransformer):
         return_dtypes = _sort_dict(self.return_dtypes)
 
         json_dict["init"]["mappings"] = {
-            column: list(column_mappings.items())
+            column: [[key, value] for key, value in column_mappings.items()]
             for column, column_mappings in mappings.items()
         }
         json_dict["init"]["return_dtypes"] = return_dtypes
@@ -516,7 +516,7 @@ class MappingTransformer(BaseMappingTransformer, BaseMappingTransformMixin):
     >>> # transformer can also be dumped to json and reinitialised
     >>> json_dump = transformer.to_json()
     >>> json_dump
-    {'tubular_version': ..., 'classname': 'MappingTransformer', 'init': {'copy': False, 'verbose': False, 'return_native': True, 'mappings': {'a': [('N', 0), ('Y', 1)]}, 'return_dtypes': {'a': 'Int8'}}, 'fit': {'is_fitted_': True}}
+    {'tubular_version': ..., 'classname': 'MappingTransformer', 'init': {'copy': False, 'verbose': False, 'return_native': True, 'mappings': {'a': [['N', 0], ['Y', 1]]}, 'return_dtypes': {'a': 'Int8'}}, 'fit': {'is_fitted_': True}}
 
     >>> MappingTransformer.from_json(json_dump)
     MappingTransformer(mappings={'a': {'N': 0, 'Y': 1}},


### PR DESCRIPTION
Closes #757

Mapping dictionaries are now serialized as key-value pairs, so JSON round trips preserve numeric keys instead of coercing them to strings. Deserialization still accepts legacy dictionary payloads.

Tested with the mapping transformer suite (357 tests) and Ruff.
