### PR TITLE
chore: refactored OtherBaseBehaviourTests to improve maintainability

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,9 +31,9 @@ Each individual change should have a link to the pull request after the descript
 -------------------
 Changed
 ^^^^^^^
-- added get_transform_exprs methods to NullIndicator transformer `#750 <https://github.com/azukds/tubular/issues/750>_`
-- added get_transform_exprs methods to BaseImputer `#751 <https://github.com/azukds/tubular/issues/751>_`
-- placeholder
+- feat: added get_transform_exprs methods to NullIndicator transformer `#750 <https://github.com/azukds/tubular/issues/750>_`
+- feat: added get_transform_exprs methods to BaseImputer `#751 <https://github.com/azukds/tubular/issues/751>_`
+- chore: refactored OtherBaseBehaviour test classes to make easier to maintain
 
 3.9.0 (17/07/2026)
 ------------------

--- a/tests/aggregations/test_AggregateColumnsOverRowTransformer.py
+++ b/tests/aggregations/test_AggregateColumnsOverRowTransformer.py
@@ -10,7 +10,6 @@ from tests.aggregations.test_BaseAggregationTransformer import (
 from tests.base_tests import (
     EmptyColumnsFitTransformPassTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsNumeric,
 )
 from tests.utils import (
     _check_if_skip_test,
@@ -211,7 +210,6 @@ class TestAggregateColumnsOverRowTransformerTransform(
 class TestOtherBaseBehaviour(
     OtherBaseBehaviourTests,
     EmptyColumnsFitTransformPassTests,
-    OtherBaseBehaviourTestsNumeric,
 ):
     """
     Class to run tests for AggregateColumnsOverRowTransformer outside the three standard methods.

--- a/tests/aggregations/test_AggregateRowsOverColumnTransformer.py
+++ b/tests/aggregations/test_AggregateRowsOverColumnTransformer.py
@@ -12,7 +12,6 @@ from tests.aggregations.test_BaseAggregationTransformer import (
 from tests.base_tests import (
     EmptyColumnsFitTransformPassTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsNumeric,
 )
 from tests.test_data import create_aggregate_over_rows_test_df
 
@@ -320,7 +319,6 @@ class TestAggregateRowsOverColumnTransformerTransform(
 class TestOtherBaseBehaviour(
     OtherBaseBehaviourTests,
     EmptyColumnsFitTransformPassTests,
-    OtherBaseBehaviourTestsNumeric,
 ):
     """
     Class to run tests for AggregateRowsOverColumnTransformer outside the three standard methods.

--- a/tests/aggregations/test_BaseAggregationTransformer.py
+++ b/tests/aggregations/test_BaseAggregationTransformer.py
@@ -5,7 +5,6 @@ from tests.base_tests import (
     ColumnStrListInitTests,
     GenericTransformTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsNumeric,
 )
 from tests.utils import (
     _check_if_skip_test,
@@ -86,7 +85,7 @@ class TestBaseAggregationTransformerTransform(GenericTransformTests):
             transformer.transform(_convert_to_lazy(test_df, lazy))
 
 
-class TestOtherBaseBehaviour(OtherBaseBehaviourTests, OtherBaseBehaviourTestsNumeric):
+class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
     """
     Class to run tests for BaseAggregationTransformer outside the three standard methods.
 

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -13,7 +13,6 @@ from beartype.roar import BeartypeCallHintParamViolation
 from sklearn.exceptions import NotFittedError
 from sklearn.pipeline import Pipeline
 
-import tests.test_data as d
 from tests.utils import (
     _check_if_skip_test,
     _collect_frame,
@@ -1485,110 +1484,25 @@ class OtherBaseBehaviourTests(
         # serialise without raising error
         joblib.dump(initialized_transformers[self.transformer_name], path)
 
-
-class OtherBaseBehaviourTestsNumeric:
-    """
-    Class to test numeric transformer with sklearn Pipelines.
-    """
-
+    @pytest.mark.parametrize(
+        "minimal_dataframe_lookup",
+        ["pandas", "polars"],
+        indirect=True,
+    )
     def test_pipeline_raises_not_fitted_error_when_unfitted(
-        self, initialized_transformers
+        self, initialized_transformers, minimal_dataframe_lookup
     ):
-        """Test that a sklearn Pipeline with Numeric transformer works when fitted, but raises NotFittedError when is_fitted_ is deleted."""
+        """Test that a sklearn Pipeline with tubular transformers works when fitted, but raises NotFittedError when is_fitted_ is deleted."""
         transformer = initialized_transformers[self.transformer_name]
-        df = d.create_numeric_df_1(library="pandas")
+        df = minimal_dataframe_lookup[self.transformer_name]
+
+        if _check_if_skip_test(transformer, df, lazy=False, from_json=False):
+            return
 
         pipeline = Pipeline([("base_transformer", transformer)])
 
         # Fit the pipeline
-        pipeline.fit(df)
-
-        # Transform should work
-        result = pipeline.transform(df)
-        assert result is not None
-
-        # Delete is_fitted_ from the transformer
-        del transformer.is_fitted_
-
-        # Now transform should raise NotFittedError
-        with pytest.raises(NotFittedError):
-            pipeline.transform(df)
-
-
-class OtherBaseBehaviourTestsString:
-    """
-    Class to test string transformer with sklearn Pipelines.
-    """
-
-    def test_pipeline_raises_not_fitted_error_when_unfitted(
-        self, initialized_transformers
-    ):
-        """Test that a sklearn Pipeline with String transformer works when fitted, but raises NotFittedError when is_fitted_ is deleted."""
-        transformer = initialized_transformers[self.transformer_name]
-        df = d.create_df_8(library="pandas")
-
-        pipeline = Pipeline([("base_transformer", transformer)])
-
-        # Fit the pipeline
-        pipeline.fit(df)
-
-        # Transform should work
-        result = pipeline.transform(df)
-        assert result is not None
-
-        # Delete is_fitted_ from the transformer
-        del transformer.is_fitted_
-
-        # Now transform should raise NotFittedError
-        with pytest.raises(NotFittedError):
-            pipeline.transform(df)
-
-
-class OtherBaseBehaviourTestsDatetime:
-    """
-    Class to test datetime transformer with sklearn Pipelines.
-    """
-
-    def test_pipeline_raises_not_fitted_error_when_unfitted(
-        self, initialized_transformers
-    ):
-        """Test that a sklearn Pipeline with datetime transformer works when fitted, but raises NotFittedError when is_fitted_ is deleted."""
-        transformer = initialized_transformers[self.transformer_name]
-        df = d.create_datediff_test_df(library="pandas")
-
-        pipeline = Pipeline([("base_transformer", transformer)])
-
-        # Fit the pipeline
-        pipeline.fit(df)
-
-        # Transform should work
-        result = pipeline.transform(df)
-        assert result is not None
-
-        # Delete is_fitted_ from the transformer
-        del transformer.is_fitted_
-
-        # Now transform should raise NotFittedError
-        with pytest.raises(NotFittedError):
-            pipeline.transform(df)
-
-
-class OtherBaseBehaviourTestsDates:
-    """
-    Class to test date transformer with sklearn Pipelines.
-    """
-
-    def test_pipeline_raises_not_fitted_error_when_unfitted(
-        self, initialized_transformers
-    ):
-        """Test that a sklearn Pipeline with date transformer works when fitted, but raises NotFittedError when is_fitted_ is deleted."""
-        transformer = initialized_transformers[self.transformer_name]
-        df = d.create_is_between_dates_df_1(library="pandas")
-
-        pipeline = Pipeline([("base_transformer", transformer)])
-
-        # Fit the pipeline
-        pipeline.fit(df)
+        pipeline.fit(df, y=df["c"])
 
         # Transform should work
         result = pipeline.transform(df)

--- a/tests/capping/test_CappingTransformer.py
+++ b/tests/capping/test_CappingTransformer.py
@@ -7,7 +7,6 @@ from tests.base_tests import (
     EmptyCappingsFitTransformPassTests,
     GenericTransformTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsNumeric,
 )
 from tests.capping.test_BaseCappingTransformer import (
     GenericCappingFitTests,
@@ -128,7 +127,6 @@ class TestLazyYSupport:
 class TestOtherBaseBehaviour(
     OtherBaseBehaviourTests,
     EmptyCappingsFitTransformPassTests,
-    OtherBaseBehaviourTestsNumeric,
 ):
     """
     Class to run tests for BaseTransformerBehaviour outside the three standard methods.

--- a/tests/capping/test_OutOfRangeNullTransformer.py
+++ b/tests/capping/test_OutOfRangeNullTransformer.py
@@ -7,7 +7,6 @@ from tests.base_tests import (
     EmptyCappingsFitTransformPassTests,
     GenericTransformTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsNumeric,
 )
 from tests.capping.test_BaseCappingTransformer import (
     GenericCappingFitTests,
@@ -191,7 +190,6 @@ class TestLazyYSupport:
 class TestOtherBaseBehaviour(
     OtherBaseBehaviourTests,
     EmptyCappingsFitTransformPassTests,
-    OtherBaseBehaviourTestsNumeric,
 ):
     """
     Class to run tests for BaseTransformerBehaviour outside the three standard methods.

--- a/tests/comparison/test_CompareTwoColumnsTransformer.py
+++ b/tests/comparison/test_CompareTwoColumnsTransformer.py
@@ -9,7 +9,6 @@ from tests.base_tests import (
     EmptyColumnsFailTests,
     GenericTransformTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsNumeric,
 )
 from tubular.functions.comparison import ConditionEnum
 
@@ -216,7 +215,7 @@ class TestCompareTwoColumnsTransformerTransform(GenericTransformTests):
         )
 
 
-class TestOtherBaseBehaviour(OtherBaseBehaviourTests, OtherBaseBehaviourTestsNumeric):
+class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
     """
     Class to run tests for CompareTwoColumnsTransformer outside the three standard methods.
 

--- a/tests/comparison/test_EqualityChecker.py
+++ b/tests/comparison/test_EqualityChecker.py
@@ -8,7 +8,6 @@ from tests.base_tests import (
     GenericTransformTests,
     NewColumnNameInitMixintests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsNumeric,
     TwoColumnListInitTests,
 )
 from tubular.comparison import EqualityChecker
@@ -90,7 +89,7 @@ class TestTransform(GenericTransformTests):
         )
 
 
-class TestOtherBaseBehaviour(OtherBaseBehaviourTests, OtherBaseBehaviourTestsNumeric):
+class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
     """
     Class to run tests for BaseTransformerBehaviour outside the three standard methods.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import pytest
 
 from tests.test_data import (
     create_aggregate_over_rows_test_df,
+    create_bool_df,
     create_is_between_dates_df_1,
     create_numeric_df_1,
     create_numeric_df_2,
@@ -198,6 +199,10 @@ def minimal_attribute_dict():
             "method": ["sin"],
             "units": "month",
         },
+        "_EnumImputer": {
+            "columns": ["b"],
+            "impute_value": "value",
+        },
         "ExtractStringComponentsTransformer": {
             "columns": ["b"],
             "by": "@",
@@ -296,14 +301,14 @@ def minimal_attribute_dict():
             "new_column_name": "c",
             "separator": "-",
         },
+        "_StringImputer": {
+            "columns": ["b"],
+            "impute_value": "missing",
+        },
         "StringContainsTransformer": {
             "columns": ["b"],
             "reference": "c",
             "reference_as_column": False,
-        },
-        "_StringImputer": {
-            "columns": ["b"],
-            "impute_value": "missing",
         },
         "ToDatetimeTransformer": {
             "columns": "a",
@@ -370,6 +375,7 @@ def minimal_dataframe_lookup(request) -> dict[str, pd.DataFrame]:
     agg_df = create_aggregate_over_rows_test_df(
         library=library,
     )
+    bool_df = create_bool_df(library=library)
     when_then_df = create_when_then_otherwise_test_df(library=library)
 
     # generally most transformers will work with num_df
@@ -411,6 +417,8 @@ def minimal_dataframe_lookup(request) -> dict[str, pd.DataFrame]:
     min_df_dict["BaseAggregationTransformer"] = agg_df
     min_df_dict["AggregateRowsOverColumnTransformer"] = agg_df
     min_df_dict["WhenThenOtherwiseTransformer"] = when_then_df
+    min_df_dict["_StringImputer"] = object_df
+    min_df_dict["_BooleanImputer"] = bool_df
 
     pyarrow_transformers = ["ExtractStringComponentsTransformer"]
 

--- a/tests/dates/test_BaseDatetimeTransformer.py
+++ b/tests/dates/test_BaseDatetimeTransformer.py
@@ -11,7 +11,6 @@ from tests.base_tests import (
     GenericTransformTests,
     NewColumnNameInitMixintests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsDatetime,
     ReturnNativeTests,
 )
 from tests.utils import _check_if_skip_test, _convert_to_lazy
@@ -118,7 +117,7 @@ class TestTransform(
         cls.transformer_name = "BaseDatetimeTransformer"
 
 
-class TestOtherBaseBehaviour(OtherBaseBehaviourTests, OtherBaseBehaviourTestsDatetime):
+class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
     """
     Class to run tests for BaseTransformerBehaviour outside the three standard methods.
 

--- a/tests/dates/test_BaseGenericDateTransformer.py
+++ b/tests/dates/test_BaseGenericDateTransformer.py
@@ -12,7 +12,6 @@ from tests.base_tests import (
     GenericTransformTests,
     NewColumnNameInitMixintests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsDatetime,
     ReturnNativeTests,
 )
 from tests.test_data import create_date_diff_different_dtypes, create_date_test_df
@@ -298,7 +297,7 @@ class TestTransform(
         cls.transformer_name = "BaseGenericDateTransformer"
 
 
-class TestOtherBaseBehaviour(OtherBaseBehaviourTests, OtherBaseBehaviourTestsDatetime):
+class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
     """
     Class to run tests for BaseTransformerBehaviour outside the three standard methods.
 

--- a/tests/dates/test_BetweenDatesTransformer.py
+++ b/tests/dates/test_BetweenDatesTransformer.py
@@ -14,7 +14,6 @@ from tests.base_tests import (
     GenericTransformTests,
     NewColumnNameInitMixintests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsDates,
 )
 from tests.dates.test_BaseGenericDateTransformer import (
     GenericDatesMixinTransformTests,
@@ -635,7 +634,7 @@ class TestTransform(
         transformer.transform(df)
 
 
-class TestOtherBaseBehaviour(OtherBaseBehaviourTests, OtherBaseBehaviourTestsDates):
+class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
     """
     Class to run tests for BaseTransformerBehaviour outside the three standard methods.
 

--- a/tests/dates/test_DateDiffLeapYearTransformer.py
+++ b/tests/dates/test_DateDiffLeapYearTransformer.py
@@ -12,7 +12,6 @@ from tests.base_tests import (
     GenericTransformTests,
     NewColumnNameInitMixintests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsDates,
     TwoColumnListInitTests,
 )
 from tests.dates.test_BaseGenericDateTransformer import (
@@ -238,7 +237,7 @@ class TestTransform(
         assert_frame_equal_dispatch(df_transformed[column_order], expected)
 
 
-class TestOtherBaseBehaviour(OtherBaseBehaviourTests, OtherBaseBehaviourTestsDates):
+class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
     """
     Class to run tests for BaseTransformerBehaviour outside the three standard methods.
 

--- a/tests/dates/test_DateDifferenceTransformer.py
+++ b/tests/dates/test_DateDifferenceTransformer.py
@@ -11,7 +11,6 @@ from tests.base_tests import (
     GenericTransformTests,
     NewColumnNameInitMixintests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsDates,
     ReturnNativeTests,
     TwoColumnListInitTests,
 )
@@ -486,7 +485,7 @@ class TestTransform(
         )
 
 
-class TestOtherBaseBehaviour(OtherBaseBehaviourTests, OtherBaseBehaviourTestsDates):
+class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
     """
     Class to run tests for BaseTransformerBehaviour outside the three standard methods.
 

--- a/tests/dates/test_DateTimeInfoExtractor.py
+++ b/tests/dates/test_DateTimeInfoExtractor.py
@@ -10,7 +10,6 @@ from tests.base_tests import (
     EmptyColumnsFitTransformPassTests,
     GenericTransformTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsDates,
 )
 from tests.dates.test_BaseDatetimeTransformer import (
     DatetimeMixinTransformTests,
@@ -823,7 +822,6 @@ class TestTransform(
 class TestOtherBaseBehaviour(
     OtherBaseBehaviourTests,
     EmptyColumnsFitTransformPassTests,
-    OtherBaseBehaviourTestsDates,
 ):
     """
     Class to run tests for BaseTransformerBehaviour outside the three standard methods.

--- a/tests/dates/test_DatetimeComponentExtractor.py
+++ b/tests/dates/test_DatetimeComponentExtractor.py
@@ -10,7 +10,6 @@ from tests.base_tests import (
     EmptyColumnsFitTransformPassTests,
     GenericTransformTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsDates,
 )
 from tests.dates.test_BaseDatetimeTransformer import (
     DatetimeMixinTransformTests,
@@ -408,7 +407,6 @@ class TestTransform(
 class TestOtherBaseBehaviour(
     OtherBaseBehaviourTests,
     EmptyColumnsFitTransformPassTests,
-    OtherBaseBehaviourTestsDates,
 ):
     """
     Class to run tests for BaseTransformerBehaviour outside the three standard methods.

--- a/tests/dates/test_DatetimeSinusoidCalculator.py
+++ b/tests/dates/test_DatetimeSinusoidCalculator.py
@@ -10,7 +10,6 @@ from tests.base_tests import (
     GenericFitTests,
     GenericTransformTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsDates,
 )
 from tests.dates.test_BaseDatetimeTransformer import DatetimeMixinTransformTests
 from tests.utils import (
@@ -520,7 +519,6 @@ class TestTransform(GenericTransformTests, DatetimeMixinTransformTests):
 class TestOtherBaseBehaviour(
     OtherBaseBehaviourTests,
     EmptyColumnsFitTransformPassTests,
-    OtherBaseBehaviourTestsDates,
 ):
     """
     Class to run tests for BaseTransformerBehaviour outside the three standard methods.

--- a/tests/dates/test_SeriesDtMethodTransformer.py
+++ b/tests/dates/test_SeriesDtMethodTransformer.py
@@ -10,7 +10,6 @@ from tests.base_tests import (
     GenericTransformTests,
     NewColumnNameInitMixintests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsDates,
 )
 from tests.dates.test_BaseDatetimeTransformer import (
     DatetimeMixinTransformTests,
@@ -196,7 +195,7 @@ class TestTransform(
         )
 
 
-class TestOtherBaseBehaviour(OtherBaseBehaviourTests, OtherBaseBehaviourTestsDates):
+class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
     """
     Class to run tests for BaseTransformerBehaviour outside the three standard methods.
 

--- a/tests/dates/test_ToDatetimeTransformer.py
+++ b/tests/dates/test_ToDatetimeTransformer.py
@@ -9,7 +9,6 @@ from tests.base_tests import (
     GenericTransformTests,
     NewColumnNameInitMixintests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsDates,
 )
 from tests.utils import (
     _check_if_skip_test,
@@ -172,7 +171,6 @@ class TestTransform(GenericTransformTests):
 class TestOtherBaseBehaviour(
     OtherBaseBehaviourTests,
     EmptyColumnsFitTransformPassTests,
-    OtherBaseBehaviourTestsDates,
 ):
     """
     Class to run tests for BaseTransformerBehaviour outside the three standard methods.

--- a/tests/imputers/test_ArbitraryImputer.py
+++ b/tests/imputers/test_ArbitraryImputer.py
@@ -13,7 +13,6 @@ from tests.base_tests import (
     GenericFitTests,
     GenericTransformTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsNumeric,
     ReturnNativeTests,
 )
 from tests.imputers.test_BaseImputer import GenericImputerTransformTests
@@ -625,7 +624,6 @@ class TestTransform(
 class TestOtherBaseBehaviour(
     OtherBaseBehaviourTests,
     EmptyColumnsFitTransformPassTests,
-    OtherBaseBehaviourTestsNumeric,
 ):
     """
     Class to run tests for BaseTransformerBehaviour outside the three standard methods.

--- a/tests/imputers/test_BaseImputer.py
+++ b/tests/imputers/test_BaseImputer.py
@@ -589,6 +589,7 @@ class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
         )
 
     # overload this test, as does not make sense for test of independent base class
+    @pytest.mark.skip
     def test_pipeline_raises_not_fitted_error_when_unfitted(self):
         return
 

--- a/tests/imputers/test_BaseImputer.py
+++ b/tests/imputers/test_BaseImputer.py
@@ -588,6 +588,10 @@ class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
             f"{x.classname()}: get_feature_names_out does not agree with output of .transform, expected {expected_new_columns} but got {output_columns}"
         )
 
+    # overload this test, as does not make sense for test of independent base class
+    def test_pipeline_raises_not_fitted_error_when_unfitted(self):
+        return
+
     @classmethod
     def setup_class(cls):
         cls.transformer_name = "BaseImputer"

--- a/tests/imputers/test_MeanImputer.py
+++ b/tests/imputers/test_MeanImputer.py
@@ -9,7 +9,6 @@ from tests.base_tests import (
     GenericFitTests,
     GenericTransformTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsNumeric,
     ReturnNativeTests,
     WeightColumnFitMixinTests,
     WeightColumnInitMixinTests,
@@ -123,7 +122,6 @@ class TestLazyYSupport:
 class TestOtherBaseBehaviour(
     OtherBaseBehaviourTests,
     EmptyColumnsFitTransformPassTests,
-    OtherBaseBehaviourTestsNumeric,
 ):
     """
     Class to run tests for BaseTransformerBehaviour behaviour outside the three standard methods.

--- a/tests/imputers/test_MedianImputer.py
+++ b/tests/imputers/test_MedianImputer.py
@@ -11,7 +11,6 @@ from tests.base_tests import (
     GenericFitTests,
     GenericTransformTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsNumeric,
     ReturnNativeTests,
     WeightColumnFitMixinTests,
     WeightColumnInitMixinTests,
@@ -112,7 +111,6 @@ class TestLazyYSupport:
 class TestOtherBaseBehaviour(
     OtherBaseBehaviourTests,
     EmptyColumnsFitTransformPassTests,
-    OtherBaseBehaviourTestsNumeric,
 ):
     """
     Class to run tests for BaseTransformerBehaviour behaviour outside the three standard methods.

--- a/tests/imputers/test_ModeImputer.py
+++ b/tests/imputers/test_ModeImputer.py
@@ -10,7 +10,6 @@ from tests.base_tests import (
     GenericFitTests,
     GenericTransformTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsNumeric,
     ReturnNativeTests,
     WeightColumnFitMixinTests,
     WeightColumnInitMixinTests,
@@ -316,7 +315,6 @@ class TestLazyYSupport:
 class TestOtherBaseBehaviour(
     OtherBaseBehaviourTests,
     EmptyColumnsFitTransformPassTests,
-    OtherBaseBehaviourTestsNumeric,
 ):
     """
     Class to run tests for BaseTransformerBehaviour outside the three standard methods.

--- a/tests/imputers/test_NearestMeanResponseImputer.py
+++ b/tests/imputers/test_NearestMeanResponseImputer.py
@@ -69,13 +69,12 @@ class TestFit(GenericFitTests):
         """Test that the nearest response values learnt during fit are expected."""
         df = d.create_numeric_df_2(library=library)
 
-        transformer = NearestMeanResponseImputer(columns=["b", "c"])
+        transformer = NearestMeanResponseImputer(columns=["b"])
 
         transformer.fit(df, df["a"])
 
         assert transformer.impute_values_ == {
             "b": np.float64(3),
-            "c": np.float64(2),
         }, "impute_values_ attribute"
 
 

--- a/tests/imputers/test_NullIndicator.py
+++ b/tests/imputers/test_NullIndicator.py
@@ -7,7 +7,6 @@ from tests.base_tests import (
     EmptyColumnsFitTransformPassTests,
     GenericTransformTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsNumeric,
     ReturnNativeTests,
 )
 from tests.utils import (
@@ -113,7 +112,6 @@ class TestTransform(GenericTransformTests, ReturnNativeTests):
 class TestOtherBaseBehaviour(
     OtherBaseBehaviourTests,
     EmptyColumnsFitTransformPassTests,
-    OtherBaseBehaviourTestsNumeric,
 ):
     """
     Class to run tests for BaseTransformerBehaviour outside the three standard methods.

--- a/tests/mapping/test_BaseCrossColumnMappingTransformer.py
+++ b/tests/mapping/test_BaseCrossColumnMappingTransformer.py
@@ -3,7 +3,7 @@ import pytest
 import test_aide as ta
 
 import tests.test_data as d
-from tests.base_tests import OtherBaseBehaviourTests, OtherBaseBehaviourTestsString
+from tests.base_tests import OtherBaseBehaviourTests
 from tests.mapping.test_BaseMappingTransformer import (
     BaseMappingTransformerInitTests,
     BaseMappingTransformerTransformTests,
@@ -144,7 +144,6 @@ class TestTransform(BaseCrossColumnMappingTransformerTransformTests):
 
 class TestOtherBaseBehaviour(
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsString,
 ):
     """
     Class to run tests for BaseCrossColumnMappingTransformer outside the three standard methods.

--- a/tests/mapping/test_BaseCrossColumnNumericTransformer.py
+++ b/tests/mapping/test_BaseCrossColumnNumericTransformer.py
@@ -1,7 +1,7 @@
 import pytest
 
 import tests.test_data as d
-from tests.base_tests import OtherBaseBehaviourTests, OtherBaseBehaviourTestsNumeric
+from tests.base_tests import OtherBaseBehaviourTests
 from tests.mapping.test_BaseCrossColumnMappingTransformer import (
     BaseCrossColumnMappingTransformerInitTests,
     BaseCrossColumnMappingTransformerTransformTests,
@@ -113,7 +113,7 @@ class TestTransform(BaseCrossColumnNumericTransformerTransformTests):
         cls.transformer_name = "BaseCrossColumnNumericTransformer"
 
 
-class TestOtherBaseBehaviour(OtherBaseBehaviourTests, OtherBaseBehaviourTestsNumeric):
+class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
     """
     Class to run tests for BaseTransformerBehaviour outside the three standard methods.
 

--- a/tests/mapping/test_BaseMappingTransformMixin.py
+++ b/tests/mapping/test_BaseMappingTransformMixin.py
@@ -532,6 +532,10 @@ class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
             f"{x.classname()}: get_feature_names_out does not agree with output of .transform, expected {expected_new_columns} but got {output_columns}"
         )
 
+    # overload this test, as does not make sense for test of independent mixin
+    def test_pipeline_raises_not_fitted_error_when_unfitted(self):
+        return
+
     @classmethod
     def setup_class(cls):
         cls.transformer_name = "BaseMappingTransformMixin"

--- a/tests/mapping/test_BaseMappingTransformMixin.py
+++ b/tests/mapping/test_BaseMappingTransformMixin.py
@@ -533,6 +533,7 @@ class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
         )
 
     # overload this test, as does not make sense for test of independent mixin
+    @pytest.mark.skip
     def test_pipeline_raises_not_fitted_error_when_unfitted(self):
         return
 

--- a/tests/mapping/test_BaseMappingTransformer.py
+++ b/tests/mapping/test_BaseMappingTransformer.py
@@ -9,7 +9,6 @@ from tests.base_tests import (
     GenericInitTests,
     GenericTransformTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsString,
 )
 from tests.utils import (
     _check_if_skip_test,
@@ -196,7 +195,7 @@ class TestTransform(BaseMappingTransformerTransformTests):
             )
 
 
-class TestOtherBaseBehaviour(OtherBaseBehaviourTests, OtherBaseBehaviourTestsString):
+class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
     """
     Class to run tests for BaseTransformerBehaviour outside the three standard methods.
 

--- a/tests/mapping/test_CrossColumnAddTransformer.py
+++ b/tests/mapping/test_CrossColumnAddTransformer.py
@@ -7,7 +7,6 @@ import tests.test_data as d
 from tests.base_tests import (
     EmptyMappingsFitTransformPassTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsNumeric,
 )
 from tests.mapping.test_BaseCrossColumnNumericTransformer import (
     BaseCrossColumnNumericTransformerInitTests,
@@ -110,7 +109,6 @@ class TestTransform(BaseCrossColumnNumericTransformerTransformTests):
 class TestOtherBaseBehaviour(
     OtherBaseBehaviourTests,
     EmptyMappingsFitTransformPassTests,
-    OtherBaseBehaviourTestsNumeric,
 ):
     """
     Class to run tests for BaseTransformerBehaviour outside the three standard methods.

--- a/tests/mapping/test_CrossColumnMappingTransformer.py
+++ b/tests/mapping/test_CrossColumnMappingTransformer.py
@@ -8,7 +8,6 @@ import tests.test_data as d
 from tests.base_tests import (
     EmptyMappingsFitTransformPassTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsString,
 )
 from tests.mapping.test_BaseCrossColumnMappingTransformer import (
     BaseCrossColumnMappingTransformerInitTests,
@@ -155,7 +154,6 @@ class TestTransform(BaseCrossColumnMappingTransformerTransformTests):
 class TestOtherBaseBehaviour(
     OtherBaseBehaviourTests,
     EmptyMappingsFitTransformPassTests,
-    OtherBaseBehaviourTestsString,
 ):
     """
     Class to run tests for BaseTransformerBehaviour outside the three standard methods.

--- a/tests/mapping/test_CrossColumnMultiplyTransformer.py
+++ b/tests/mapping/test_CrossColumnMultiplyTransformer.py
@@ -7,7 +7,6 @@ import tests.test_data as d
 from tests.base_tests import (
     EmptyMappingsFitTransformPassTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsNumeric,
 )
 from tests.mapping.test_BaseCrossColumnNumericTransformer import (
     BaseCrossColumnNumericTransformerInitTests,
@@ -116,7 +115,6 @@ class TestTransform(BaseCrossColumnNumericTransformerTransformTests):
 class TestOtherBaseBehaviour(
     OtherBaseBehaviourTests,
     EmptyMappingsFitTransformPassTests,
-    OtherBaseBehaviourTestsNumeric,
 ):
     """
     Class to run tests for BaseTransformerBehaviour outside the three standard methods.

--- a/tests/mapping/test_MappingTransformer.py
+++ b/tests/mapping/test_MappingTransformer.py
@@ -8,7 +8,6 @@ from tests.mapping.test_BaseMappingTransformer import (
     BaseMappingTransformerTransformTests,
     GenericFitTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsString,
 )
 from tests.utils import (
     _check_if_skip_test,
@@ -342,7 +341,6 @@ class TestTransform(BaseMappingTransformerTransformTests, ReturnNativeTests):
 class TestOtherBaseBehaviour(
     OtherBaseBehaviourTests,
     EmptyMappingsFitTransformPassTests,
-    OtherBaseBehaviourTestsString,
 ):
     """
     Class to run tests for BaseTransformerBehaviour outside the three standard methods.

--- a/tests/misc/test_ColumnDtypeSetter.py
+++ b/tests/misc/test_ColumnDtypeSetter.py
@@ -10,7 +10,6 @@ from tests.base_tests import (
     GenericFitTests,
     GenericTransformTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsNumeric,
 )
 from tests.utils import (
     _check_if_skip_test,
@@ -232,7 +231,6 @@ class TestTransform(GenericTransformTests):
 class TestOtherBaseBehaviour(
     OtherBaseBehaviourTests,
     EmptyColumnsFitTransformPassTests,
-    OtherBaseBehaviourTestsNumeric,
 ):
     """
     Class to run tests for ColumnDtypeSetter behaviour outside the three standard methods.

--- a/tests/misc/test_RenameColumnsTransformer.py
+++ b/tests/misc/test_RenameColumnsTransformer.py
@@ -7,7 +7,6 @@ from tests.base_tests import (
     GenericFitTests,
     GenericTransformTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsNumeric,
 )
 from tests.utils import (
     _check_if_skip_test,
@@ -163,7 +162,6 @@ class TestTransform(GenericTransformTests):
 class TestOtherBaseBehaviour(
     OtherBaseBehaviourTests,
     EmptyColumnsFitTransformPassTests,
-    OtherBaseBehaviourTestsNumeric,
 ):
     """
     Class to run tests for RenameColumnsTransformer behaviour outside the three standard methods.

--- a/tests/misc/test_SetValueTransformer.py
+++ b/tests/misc/test_SetValueTransformer.py
@@ -10,7 +10,6 @@ from tests.base_tests import (
     GenericFitTests,
     GenericTransformTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsNumeric,
 )
 from tests.utils import (
     _check_if_skip_test,
@@ -105,7 +104,6 @@ class TestTransform(GenericTransformTests):
 class TestOtherBaseBehaviour(
     OtherBaseBehaviourTests,
     EmptyColumnsFitTransformPassTests,
-    OtherBaseBehaviourTestsNumeric,
 ):
     """
     Class to run tests for SetValueTransformer behaviour outside the three standard methods.

--- a/tests/nominal/test_GroupRareLevelsTransformer.py
+++ b/tests/nominal/test_GroupRareLevelsTransformer.py
@@ -15,7 +15,6 @@ from tests.base_tests import (
     EmptyColumnsFitTransformPassTests,
     GenericFitTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsString,
     WeightColumnFitMixinTests,
     WeightColumnInitMixinTests,
 )
@@ -566,7 +565,6 @@ class TestLazyYSupport:
 class TestOtherBaseBehaviour(
     OtherBaseBehaviourTests,
     EmptyColumnsFitTransformPassTests,
-    OtherBaseBehaviourTestsString,
 ):
     """
     Class to run tests for BaseTransformerBehaviour outside the three standard methods.

--- a/tests/nominal/test_NominalToIntegerTransformer.py
+++ b/tests/nominal/test_NominalToIntegerTransformer.py
@@ -10,7 +10,6 @@ from tests.base_tests import (
     EmptyColumnsFitTransformPassTests,
     GenericFitTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsString,
 )
 from tubular.mapping import BaseMappingTransformer
 from tubular.nominal import NominalToIntegerTransformer
@@ -158,7 +157,6 @@ class TestTransform(GenericNominalTransformTests):
 class TestOtherBaseBehaviour(
     OtherBaseBehaviourTests,
     EmptyColumnsFitTransformPassTests,
-    OtherBaseBehaviourTestsString,
 ):
     """
     Class to run tests for BaseTransformerBehaviour outside the three standard methods.

--- a/tests/nominal/test_OneHotEncodingTransformer.py
+++ b/tests/nominal/test_OneHotEncodingTransformer.py
@@ -12,7 +12,6 @@ from tests.base_tests import (
     GenericFitTests,
     GenericTransformTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsString,
     SeparatorInitMixintests,
 )
 from tests.utils import (
@@ -564,7 +563,6 @@ class TestLazyYSupport:
 class TestOtherBaseBehaviour(
     OtherBaseBehaviourTests,
     EmptyColumnsFitTransformPassTests,
-    OtherBaseBehaviourTestsString,
 ):
     """
     Class to run tests for BaseTransformerBehaviour outside the three standard methods.

--- a/tests/numeric/test_CutTransformer.py
+++ b/tests/numeric/test_CutTransformer.py
@@ -8,7 +8,6 @@ from tests.base_tests import (
     EmptyColumnsFailTests,
     NewColumnNameInitMixintests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsNumeric,
 )
 from tests.numeric.test_BaseNumericTransformer import (
     BaseNumericTransformerInitTests,
@@ -127,7 +126,7 @@ class TestTransform(BaseNumericTransformerTransformTests):
         )
 
 
-class TestOtherBaseBehaviour(OtherBaseBehaviourTests, OtherBaseBehaviourTestsNumeric):
+class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
     """
     Class to run tests for CutTransformer outside the three standard methods.
 

--- a/tests/numeric/test_DifferenceTransformer.py
+++ b/tests/numeric/test_DifferenceTransformer.py
@@ -8,7 +8,6 @@ from tests import utils as u
 from tests.base_tests import (
     EmptyColumnsFailTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsNumeric,
 )
 from tests.numeric.test_BaseNumericTransformer import (
     BaseNumericTransformerInitTests,
@@ -212,7 +211,7 @@ class TestDifferenceTransformerTransform(BaseNumericTransformerTransformTests):
         )
 
 
-class TestOtherBaseBehaviour(OtherBaseBehaviourTests, OtherBaseBehaviourTestsNumeric):
+class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
     """
     Class to run tests for DifferenceTransformer outside the three standard methods.
 

--- a/tests/numeric/test_InteractionTransformer.py
+++ b/tests/numeric/test_InteractionTransformer.py
@@ -8,7 +8,6 @@ import tests.test_data as d
 from tests.base_tests import (
     EmptyColumnsFailTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsNumeric,
 )
 from tests.numeric.test_BaseNumericTransformer import (
     BaseNumericTransformerInitTests,
@@ -164,7 +163,7 @@ class TestTransform(BaseNumericTransformerTransformTests):
         )
 
 
-class TestOtherBaseBehaviour(OtherBaseBehaviourTests, OtherBaseBehaviourTestsNumeric):
+class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
     """
     Class to run tests for InteractionTransformer outside the three standard methods.
 

--- a/tests/numeric/test_LogTransformer.py
+++ b/tests/numeric/test_LogTransformer.py
@@ -10,7 +10,6 @@ import tests.test_data as d
 from tests.base_tests import (
     EmptyColumnsFitTransformPassTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsNumeric,
 )
 from tests.numeric.test_BaseNumericTransformer import (
     BaseNumericTransformerInitTests,
@@ -318,7 +317,6 @@ class TestTransform(
 class TestOtherBaseBehaviour(
     OtherBaseBehaviourTests,
     EmptyColumnsFitTransformPassTests,
-    OtherBaseBehaviourTestsNumeric,
 ):
     """
     Class to run tests for LogTransformer outside the three standard methods.

--- a/tests/numeric/test_OneDKmeansTransformer.py
+++ b/tests/numeric/test_OneDKmeansTransformer.py
@@ -6,7 +6,6 @@ import tests.utils as u
 from tests.base_tests import (
     EmptyColumnsFailTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsNumeric,
 )
 from tests.numeric.test_BaseNumericTransformer import (
     BaseNumericTransformerFitTests,
@@ -252,7 +251,7 @@ class TestTransform(
         u.assert_frame_equal_dispatch(expected, df_transformed)
 
 
-class TestOtherBaseBehaviour(OtherBaseBehaviourTests, OtherBaseBehaviourTestsNumeric):
+class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
     """
     Class to run tests for OneDKmeansTransformer outside the three standard methods.
 

--- a/tests/numeric/test_PCATransformer.py
+++ b/tests/numeric/test_PCATransformer.py
@@ -11,7 +11,6 @@ from tests.base_tests import (
     GenericFitTests,
     GenericTransformTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsNumeric,
 )
 from tubular.numeric import PCATransformer
 
@@ -343,7 +342,7 @@ class TestTransform(GenericTransformTests):
         )
 
 
-class TestOtherBaseBehaviour(OtherBaseBehaviourTests, OtherBaseBehaviourTestsNumeric):
+class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
     """
     Class to run tests for PCATransformer outside the three standard methods.
 

--- a/tests/numeric/test_ScalingTransformer.py
+++ b/tests/numeric/test_ScalingTransformer.py
@@ -4,7 +4,6 @@ import pytest
 from tests.base_tests import (
     EmptyColumnsFitTransformPassTests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsNumeric,
 )
 from tests.numeric.test_BaseNumericTransformer import (
     BaseNumericTransformerFitTests,
@@ -115,7 +114,6 @@ class TestTransform(BaseNumericTransformerTransformTests):
 class TestOtherBaseBehaviour(
     OtherBaseBehaviourTests,
     EmptyColumnsFitTransformPassTests,
-    OtherBaseBehaviourTestsNumeric,
 ):
     """
     Class to run tests for ScalingTransformer outside the three standard methods.

--- a/tests/numeric/test_TwoColumnOperatorTransformer.py
+++ b/tests/numeric/test_TwoColumnOperatorTransformer.py
@@ -6,7 +6,6 @@ from tests.base_tests import (
     EmptyColumnsFailTests,
     NewColumnNameInitMixintests,
     OtherBaseBehaviourTests,
-    OtherBaseBehaviourTestsNumeric,
     TwoColumnListInitTests,
 )
 from tests.numeric.test_BaseNumericTransformer import (
@@ -80,7 +79,7 @@ class TestTransform(BaseNumericTransformerTransformTests):
         )
 
 
-class TestOtherBaseBehaviour(OtherBaseBehaviourTests, OtherBaseBehaviourTestsNumeric):
+class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
     """
     Class to run tests for BaseTransformerBehaviour outside the three standard methods.
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -30,10 +30,27 @@ def create_numeric_df_2(library="pandas"):
     df_dict = {
         "a": [2, 3, 2, 1, 4, 1],
         "b": [None, None, 1, 3, 3, 4],
-        "c": [1, 1, 2, 3, 3, None],
+        "c": [1, 1, 2, 3, 3, 3],
     }
 
     return u.dataframe_init_dispatch(df_dict, library)
+
+
+def create_bool_df(library="pandas"):
+    """Example with boolean dataframe that includes missing values."""
+
+    df_dict = {
+        "a": [True, False, None],
+        "b": [True, None, False],
+        "c": [1, 1, 0],
+    }
+
+    df = u.dataframe_init_dispatch(df_dict, library)
+
+    df = nw.from_native(df)
+    df = nw.maybe_convert_dtypes(df)
+
+    return df.to_native()
 
 
 def create_object_df(library="pandas"):
@@ -42,10 +59,24 @@ def create_object_df(library="pandas"):
     df_dict = {
         "a": [1, 2, 3, 4, 5],
         "b": ["f", "g", "h", "i", "j"],
-        "c": ["a", "b", "c", "d", "e"],
+        "c": [1, 0, 1, 0, 1],
     }
 
     return u.dataframe_init_dispatch(df_dict, library)
+
+
+def create_categorical_df(library="pandas"):
+    """Example with object columns - c is numeric target"""
+
+    df_dict = {"a": ["f", "g", None], "b": ["a", "b", None], "c": [1, 0, 1]}
+
+    df = u.dataframe_init_dispatch(df_dict, library)
+
+    df = nw.from_native(df)
+
+    df = df.with_columns(nw.col(col).cast(nw.Categorical) for col in ["a", "b"])
+
+    return df.to_native()
 
 
 def create_df_1(library="pandas"):

--- a/tubular/strings.py
+++ b/tubular/strings.py
@@ -155,6 +155,8 @@ class LowerCaseTransformer(BaseTransformer):
         """
         X = _convert_dataframe_to_narwhals(X)
 
+        X = super().transform(X, return_native_override=False)
+
         transform_exprs = self.get_transform_exprs()
 
         X = X.with_columns(*transform_exprs) if transform_exprs else X
@@ -377,6 +379,8 @@ class ExtractStringComponentsTransformer(BaseTransformer):
         """
         X = _convert_dataframe_to_narwhals(X)
 
+        X = super().transform(X, return_native_override=False)
+
         transform_exprs = self.get_transform_exprs()
 
         X = X.with_columns(*transform_exprs) if transform_exprs else X
@@ -557,6 +561,8 @@ class RemoveCharactersTransformer(BaseTransformer):
 
         """
         X = _convert_dataframe_to_narwhals(X)
+
+        X = super().transform(X, return_native_override=False)
 
         transform_exprs = self.get_transform_exprs()
 
@@ -788,6 +794,8 @@ class StringContainsTransformer(BaseTransformer):
 
         """
         X = _convert_dataframe_to_narwhals(X)
+
+        X = super().transform(X, return_native_override=False)
 
         backend = nw.get_native_namespace(X).__name__
 


### PR DESCRIPTION
made some simplifying changes to make upcoming imputer PRs easier - basically changed tests to utilise minimal_dataframe_lookup more rather than having type specific e.g. 'OtherBaseBehaviourTestsNumeric' classes