### PR TITLE
Feature/numberimputer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,7 @@ Changed
 - feat: added get_transform_exprs methods to NullIndicator transformer `#750 <https://github.com/azukds/tubular/issues/750>_`
 - feat: added get_transform_exprs methods to BaseImputer `#751 <https://github.com/azukds/tubular/issues/751>_`
 - chore: refactored OtherBaseBehaviour test classes to make easier to maintain
+- feat: added tests for NumberImputer and made public `#752 <https://github.com/azukds/tubular/issues/752>_`
 
 3.9.0 (17/07/2026)
 ------------------

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ track our progress below:
 | MedianImputer                      | :heavy_check_mark:  | :heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark:     |
 | ModeImputer                        | :heavy_check_mark:  | :heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark:     |
 | NullIndicator                      | :heavy_check_mark:  | :heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark:     |
+| NumberImputer                      | :heavy_check_mark:  | :heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark:     |
 | OneDKmeansTransformer              | :heavy_check_mark:  | :heavy_check_mark:  | :heavy_check_mark: | :x:                    |
 | OneHotEncodingTransformer          | :heavy_check_mark:  | :heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark:     |
 | OutOfRangeNullTransformer          | :heavy_check_mark:  | :heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark:     |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -249,7 +249,7 @@ def minimal_attribute_dict():
         "NullIndicator": {
             "columns": ["a"],
         },
-        "_NumberImputer": {
+        "NumberImputer": {
             "columns": ["b"],
             "impute_value": 1,
         },

--- a/tests/imputers/test_ArbitraryImputer.py
+++ b/tests/imputers/test_ArbitraryImputer.py
@@ -142,7 +142,7 @@ class TestTransform(
         else:
             col_dtype = getattr(nw, col_type)
             msg = f"""
-                ArbitraryImputer: transformer can only handle Float/Int/UInt/Unknown type columns
+                NumberImputer: transformer can only handle Float/Int/UInt/Unknown type columns
                 but got columns with types {[col_dtype]}
                 """
 
@@ -609,7 +609,7 @@ class TestTransform(
 
         msg = re.escape(
             f"""
-                ArbitraryImputer: transformer can only handle Float/Int/UInt/Unknown type columns
+                NumberImputer: transformer can only handle Float/Int/UInt/Unknown type columns
                 but got columns with types {bad_types}
                 """,
         )

--- a/tests/imputers/test_NumberImputer.py
+++ b/tests/imputers/test_NumberImputer.py
@@ -1,0 +1,289 @@
+import re
+
+import narwhals as nw
+import pandas as pd
+import polars as pl
+import pytest
+
+import tests.utils as u
+from tests.base_tests import (
+    ColumnStrListInitTests,
+    EmptyColumnsFitTransformPassTests,
+    GenericFitTests,
+    GenericTransformTests,
+    OtherBaseBehaviourTests,
+    ReturnNativeTests,
+)
+from tests.utils import _handle_from_json
+from tubular.imputers import NumberImputer
+
+
+class TestInit(ColumnStrListInitTests):
+    """Generic tests for transformer.init()."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "NumberImputer"
+
+    def test_bad_impute_value_error(self):
+        pass
+
+
+class TestFit(GenericFitTests):
+    """Generic tests for transformer.fit()"""
+
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "NumberImputer"
+
+
+class TestTransform(
+    GenericTransformTests,
+    ReturnNativeTests,
+):
+    """Tests for transformer.transform."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "NumberImputer"
+
+    @pytest.mark.parametrize(
+        "lazy",
+        [True, False],
+    )
+    @pytest.mark.parametrize("from_json", [True, False])
+    @pytest.mark.parametrize("library", ["pandas", "polars"])
+    @pytest.mark.parametrize(
+        "input_values",
+        [
+            [["a", "b"], ["c", "d"]],
+            [{"a": 1}, {"b": 4}],
+            ["a", "b"],
+            [True, False],
+        ],
+    )
+    def test_type_mismatch_errors(
+        self,
+        input_values,
+        library,
+        lazy,
+        from_json,
+    ):
+        """Test that unexpected dtypes will hit error"""
+
+        column = "a"
+        df_dict = {column: input_values}
+
+        # because of weird types, initialise manually
+        df = pd.DataFrame(df_dict) if library == "pandas" else pl.DataFrame(df_dict)
+
+        transformer = NumberImputer(impute_value=1, columns=[column])
+
+        if u._check_if_skip_test(transformer, df, lazy, from_json):
+            return
+
+        transformer = _handle_from_json(transformer, from_json)
+
+        bad_types = [nw.from_native(df).schema[column]]
+
+        msg = f"""
+                ArbitraryImputer: transformer can only handle Float/Int/UInt/Unknown type columns
+                but got columns with types {bad_types}
+                """
+
+        with pytest.raises(
+            TypeError,
+            match=re.escape(msg),
+        ):
+            transformer.transform(u._convert_to_lazy(df, lazy))
+
+    @pytest.mark.parametrize(
+        "lazy",
+        [True, False],
+    )
+    @pytest.mark.parametrize("from_json", [True, False])
+    @pytest.mark.parametrize("library", ["pandas", "polars"])
+    def test_impute_value_not_changed_by_transform(
+        self,
+        library,
+        lazy,
+        from_json,
+    ):
+        """Test outputs for expected cases."""
+
+        column = "a"
+        input_col = [1.0, None]
+        impute_value = 2
+        df_dict = {"a": input_col}
+
+        df = u.dataframe_init_dispatch(dataframe_dict=df_dict, library=library)
+
+        df_nw = nw.from_native(df)
+
+        transformer = NumberImputer(impute_value=impute_value, columns=[column])
+
+        if u._check_if_skip_test(transformer, df, lazy, from_json):
+            return
+
+        transformer = _handle_from_json(transformer, from_json)
+
+        _ = transformer.transform(
+            u._convert_to_lazy(df_nw.to_native(), lazy),
+        )
+
+        # check impute value not changed in transform
+        assert transformer.impute_value == impute_value, (
+            "impute_values_ changed in transform"
+        )
+
+    @pytest.mark.parametrize(
+        "lazy",
+        [True, False],
+    )
+    @pytest.mark.parametrize("from_json", [True, False])
+    @pytest.mark.parametrize("library", ["pandas", "polars"])
+    @pytest.mark.parametrize(
+        ("input_col", "impute_value", "expected_values"),
+        [
+            ([1.0, None, 3.0], 2, [1.0, 2.0, 3.0]),
+            ([None, None, None], 2, [2.0, 2.0, 2.0]),
+            ([1, None, 3], 2, [1.0, 2.0, 3.0]),
+            # test with decimal numbers
+            ([1.3, 2.2, None], 1.1, [1.3, 2.2, 1.1]),
+            # test imputing with falsey value
+            ([1, None, 3], 0, [1.0, 0.0, 3.0]),
+        ],
+    )
+    def test_output(
+        self,
+        input_col,
+        impute_value,
+        expected_values,
+        library,
+        lazy,
+        from_json,
+    ):
+        """Test outputs for expected cases."""
+
+        column = "a"
+        df_dict = {"a": input_col}
+        expected_dtype = "Float64"
+
+        df = u.dataframe_init_dispatch(dataframe_dict=df_dict, library=library)
+
+        df_nw = nw.from_native(df)
+
+        if all(val is None for val in input_col):
+            df_nw = df_nw.with_columns(nw.col("a").cast(getattr(nw, expected_dtype)))
+
+        transformer = NumberImputer(impute_value=impute_value, columns=[column])
+
+        if u._check_if_skip_test(transformer, df, lazy, from_json):
+            return
+
+        transformer = _handle_from_json(transformer, from_json)
+
+        df_transformed_native = transformer.transform(
+            u._convert_to_lazy(df_nw.to_native(), lazy),
+        )
+
+        # check impute value not changed in transform
+        assert transformer.impute_value == impute_value, (
+            "impute_values_ changed in transform"
+        )
+
+        df_transformed_nw = nw.from_native(
+            u._collect_frame(df_transformed_native, lazy),
+        )
+
+        actual_dtype = str(df_transformed_nw[column].dtype)
+        assert actual_dtype == expected_dtype, (
+            f"{self.transformer_name}: dtype changed unexpectedly in transform, expected {expected_dtype} but got {actual_dtype}"
+        )
+
+        # also check full df against expectation
+        expected = df_nw.clone()
+        expected = expected.with_columns(
+            nw.new_series(name=column, values=expected_values, backend=library)
+        )
+
+        u.assert_frame_equal_dispatch(
+            expected.to_native(),
+            df_transformed_nw.to_native(),
+        )
+
+    @pytest.mark.parametrize("from_json", [True, False])
+    @pytest.mark.parametrize(
+        "lazy",
+        [True, False],
+    )
+    def test_polars_unknown_type_output(
+        self,
+        lazy,
+        from_json,
+    ):
+        """Test handling of polars Unknown type column (output type should be inferred from impute_value)
+
+        Test separately to pandas, as pandas does not have equivalent type.
+        """
+
+        column = "a"
+        values = [None, None]
+        df_dict = {"a": values}
+
+        df = pl.DataFrame(df_dict)
+
+        df_nw = nw.from_native(df)
+
+        impute_value = 1
+        expected_type = "Int32"
+        transformer = NumberImputer(impute_value=impute_value, columns=[column])
+
+        if u._check_if_skip_test(transformer, df, lazy, from_json):
+            return
+
+        transformer = _handle_from_json(transformer, from_json)
+
+        df_transformed_native = transformer.transform(
+            u._convert_to_lazy(df_nw.to_native(), lazy),
+        )
+
+        df_transformed_nw = nw.from_native(
+            u._collect_frame(df_transformed_native, lazy),
+        )
+
+        actual_dtype = str(df_transformed_nw[column].dtype)
+
+        assert actual_dtype == expected_type, (
+            f"{self.transformer_name}: dtype changed unexpectedly in transform, expected {expected_type} but got {actual_dtype}"
+        )
+
+        # also check full df against expectation
+        expected = df_nw.clone()
+        expected = expected.with_columns(
+            nw.new_series(
+                name=column,
+                values=[impute_value, impute_value],
+                backend="polars",
+            ).cast(getattr(nw, expected_type)),
+        )
+
+        u.assert_frame_equal_dispatch(
+            expected.to_native(),
+            df_transformed_nw.to_native(),
+        )
+
+
+class TestOtherBaseBehaviour(
+    OtherBaseBehaviourTests,
+    EmptyColumnsFitTransformPassTests,
+):
+    """
+    Class to run tests for Transformer behaviour outside the three standard methods.
+
+    May need to overwrite specific tests in this class if the tested transformer modifies this behaviour.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "NumberImputer"

--- a/tests/imputers/test_NumberImputer.py
+++ b/tests/imputers/test_NumberImputer.py
@@ -93,7 +93,7 @@ class TestTransform(
         bad_types = [nw.from_native(df).schema[column]]
 
         msg = f"""
-                ArbitraryImputer: transformer can only handle Float/Int/UInt/Unknown type columns
+                NumberImputer: transformer can only handle Float/Int/UInt/Unknown type columns
                 but got columns with types {bad_types}
                 """
 

--- a/tests/imputers/test_NumberImputer.py
+++ b/tests/imputers/test_NumberImputer.py
@@ -5,7 +5,6 @@ import pandas as pd
 import polars as pl
 import pytest
 
-import tests.utils as u
 from tests.base_tests import (
     ColumnStrListInitTests,
     EmptyColumnsFitTransformPassTests,
@@ -14,7 +13,14 @@ from tests.base_tests import (
     OtherBaseBehaviourTests,
     ReturnNativeTests,
 )
-from tests.utils import _handle_from_json
+from tests.utils import (
+    _check_if_skip_test,
+    _collect_frame,
+    _convert_to_lazy,
+    _handle_from_json,
+    assert_frame_equal_dispatch,
+    dataframe_init_dispatch,
+)
 from tubular.imputers import NumberImputer
 
 
@@ -79,7 +85,7 @@ class TestTransform(
 
         transformer = NumberImputer(impute_value=1, columns=[column])
 
-        if u._check_if_skip_test(transformer, df, lazy, from_json):
+        if _check_if_skip_test(transformer, df, lazy, from_json):
             return
 
         transformer = _handle_from_json(transformer, from_json)
@@ -95,7 +101,7 @@ class TestTransform(
             TypeError,
             match=re.escape(msg),
         ):
-            transformer.transform(u._convert_to_lazy(df, lazy))
+            transformer.transform(_convert_to_lazy(df, lazy))
 
     @pytest.mark.parametrize(
         "lazy",
@@ -116,19 +122,19 @@ class TestTransform(
         impute_value = 2
         df_dict = {"a": input_col}
 
-        df = u.dataframe_init_dispatch(dataframe_dict=df_dict, library=library)
+        df = dataframe_init_dispatch(dataframe_dict=df_dict, library=library)
 
         df_nw = nw.from_native(df)
 
         transformer = NumberImputer(impute_value=impute_value, columns=[column])
 
-        if u._check_if_skip_test(transformer, df, lazy, from_json):
+        if _check_if_skip_test(transformer, df, lazy, from_json):
             return
 
         transformer = _handle_from_json(transformer, from_json)
 
         _ = transformer.transform(
-            u._convert_to_lazy(df_nw.to_native(), lazy),
+            _convert_to_lazy(df_nw.to_native(), lazy),
         )
 
         # check impute value not changed in transform
@@ -169,7 +175,7 @@ class TestTransform(
         df_dict = {"a": input_col}
         expected_dtype = "Float64"
 
-        df = u.dataframe_init_dispatch(dataframe_dict=df_dict, library=library)
+        df = dataframe_init_dispatch(dataframe_dict=df_dict, library=library)
 
         df_nw = nw.from_native(df)
 
@@ -178,13 +184,13 @@ class TestTransform(
 
         transformer = NumberImputer(impute_value=impute_value, columns=[column])
 
-        if u._check_if_skip_test(transformer, df, lazy, from_json):
+        if _check_if_skip_test(transformer, df, lazy, from_json):
             return
 
         transformer = _handle_from_json(transformer, from_json)
 
         df_transformed_native = transformer.transform(
-            u._convert_to_lazy(df_nw.to_native(), lazy),
+            _convert_to_lazy(df_nw.to_native(), lazy),
         )
 
         # check impute value not changed in transform
@@ -193,7 +199,7 @@ class TestTransform(
         )
 
         df_transformed_nw = nw.from_native(
-            u._collect_frame(df_transformed_native, lazy),
+            _collect_frame(df_transformed_native, lazy),
         )
 
         actual_dtype = str(df_transformed_nw[column].dtype)
@@ -207,10 +213,23 @@ class TestTransform(
             nw.new_series(name=column, values=expected_values, backend=library)
         )
 
-        u.assert_frame_equal_dispatch(
+        assert_frame_equal_dispatch(
             expected.to_native(),
             df_transformed_nw.to_native(),
         )
+
+        # Check outcomes for single rows
+        expected = nw.from_native(expected)
+        for i in range(len(df_nw)):
+            df_transformed_row = transformer.transform(
+                _convert_to_lazy(df_nw[[i]].to_native(), lazy)
+            )
+            df_expected_row = expected[[i]].to_native()
+
+            assert_frame_equal_dispatch(
+                _collect_frame(df_transformed_row, lazy),
+                df_expected_row,
+            )
 
     @pytest.mark.parametrize("from_json", [True, False])
     @pytest.mark.parametrize(
@@ -239,17 +258,17 @@ class TestTransform(
         expected_type = "Int32"
         transformer = NumberImputer(impute_value=impute_value, columns=[column])
 
-        if u._check_if_skip_test(transformer, df, lazy, from_json):
+        if _check_if_skip_test(transformer, df, lazy, from_json):
             return
 
         transformer = _handle_from_json(transformer, from_json)
 
         df_transformed_native = transformer.transform(
-            u._convert_to_lazy(df_nw.to_native(), lazy),
+            _convert_to_lazy(df_nw.to_native(), lazy),
         )
 
         df_transformed_nw = nw.from_native(
-            u._collect_frame(df_transformed_native, lazy),
+            _collect_frame(df_transformed_native, lazy),
         )
 
         actual_dtype = str(df_transformed_nw[column].dtype)
@@ -268,10 +287,23 @@ class TestTransform(
             ).cast(getattr(nw, expected_type)),
         )
 
-        u.assert_frame_equal_dispatch(
+        assert_frame_equal_dispatch(
             expected.to_native(),
             df_transformed_nw.to_native(),
         )
+
+        # Check outcomes for single rows
+        expected = nw.from_native(expected)
+        for i in range(len(df_nw)):
+            df_transformed_row = transformer.transform(
+                _convert_to_lazy(df_nw[[i]].to_native(), lazy)
+            )
+            df_expected_row = expected[[i]].to_native()
+
+            assert_frame_equal_dispatch(
+                _collect_frame(df_transformed_row, lazy),
+                df_expected_row,
+            )
 
 
 class TestOtherBaseBehaviour(

--- a/tubular/__init__.py
+++ b/tubular/__init__.py
@@ -24,6 +24,7 @@ from tubular.imputers import (
     MedianImputer,
     ModeImputer,
     NullIndicator,
+    NumberImputer,
 )
 from tubular.mapping import MappingTransformer
 from tubular.misc import (
@@ -64,6 +65,7 @@ __all__ = [
     "MedianImputer",
     "ModeImputer",
     "NullIndicator",
+    "NumberImputer",
     "OneDKmeansTransformer",
     "OneHotEncodingTransformer",
     "OutOfRangeNullTransformer",

--- a/tubular/functions/imputers.py
+++ b/tubular/functions/imputers.py
@@ -21,10 +21,10 @@ def indicate_nulls_for_columns(columns: ListOfStrs | str) -> list[nw.Expr]:
     return [(nw.col(c).is_null()).alias(f"{c}_nulls") for c in columns]
 
 
-def impute_numeric_nulls(
+def impute_numeric_or_string_nulls(
     columns: ListOfStrs | list, impute_values: dict
 ) -> list[nw.Expr]:
-    """Return expressions to impute null values for numeric columns.
+    """Return expressions to impute null values for numeric or string columns.
 
     Parameters
     ----------

--- a/tubular/imputers.py
+++ b/tubular/imputers.py
@@ -261,7 +261,7 @@ class BaseImputer(BaseTransformer):
 
 
 class NumberImputer(BaseImputer):
-    """Private subclass to handle arbitrary number imputation.
+    """Class to handle arbitrary number imputation.
 
     Attributes
     ----------

--- a/tubular/imputers.py
+++ b/tubular/imputers.py
@@ -24,7 +24,10 @@ from tubular._utils import (
     block_from_json,
 )
 from tubular.base import BaseTransformer, register
-from tubular.functions.imputers import impute_numeric_nulls, indicate_nulls_for_columns
+from tubular.functions.imputers import (
+    impute_numeric_or_string_nulls,
+    indicate_nulls_for_columns,
+)
 from tubular.mixins import WeightColumnMixin
 from tubular.types import DataFrame, LazyFrame, ListOfStrs, NumericTypes, Series
 
@@ -137,7 +140,7 @@ class BaseImputer(BaseTransformer):
             ),
         ):
             json_dict["init"]["weights_column"] = self.weights_column
-        elif isinstance(self, ArbitraryImputer):
+        elif isinstance(self, (ArbitraryImputer, NumberImputer)):
             json_dict["init"]["impute_value"] = self.impute_value
 
         json_dict["fit"]["impute_values_"] = _sort_dict(self.impute_values_)
@@ -190,7 +193,7 @@ class BaseImputer(BaseTransformer):
         list[nw.Expr]: transform expressions for class
 
         """
-        return impute_numeric_nulls(
+        return impute_numeric_or_string_nulls(
             columns=self.columns, impute_values=self.impute_values_
         )
 
@@ -257,7 +260,7 @@ class BaseImputer(BaseTransformer):
         return _return_narwhals_or_native_dataframe(X, return_native)
 
 
-class _NumberImputer(BaseImputer):
+class NumberImputer(BaseImputer):
     """Private subclass to handle arbitrary number imputation.
 
     Attributes
@@ -345,7 +348,7 @@ class _NumberImputer(BaseImputer):
         ```pycon
         >>> import polars as pl
         >>> test_df = pl.DataFrame({"a": [1, None, 2], "b": [3, None, 4]})
-        >>> imputer = _NumberImputer(columns=["a", "b"], impute_value=5)
+        >>> imputer = NumberImputer(columns=["a", "b"], impute_value=5)
         >>> imputer.transform(test_df)
         shape: (3, 2)
         ┌─────┬─────┐
@@ -368,7 +371,7 @@ class _NumberImputer(BaseImputer):
         bad_types = [
             schema[col]
             for col in self.columns
-            if schema[col] not in {*NumericTypes, nw.Unknown}
+            if not isinstance(schema[col], (*NumericTypes, nw.Unknown))
         ]
 
         if bad_types:
@@ -383,15 +386,9 @@ class _NumberImputer(BaseImputer):
         X = BaseTransformer.transform(self, X, return_native_override=False)
 
         # next handle imputing
-        transform_expressions = {
-            col: self._generate_imputation_expressions(
-                nw.col(col),
-                col,
-            )
-            for col in self.columns
-        }
+        transform_exprs = self.get_transform_exprs()
 
-        X = X.with_columns(**transform_expressions) if transform_expressions else X
+        X = X.with_columns(*transform_exprs) if transform_exprs else X
 
         return _return_narwhals_or_native_dataframe(X, self.return_native)
 
@@ -846,7 +843,7 @@ class ArbitraryImputer(BaseImputer):
         if isinstance(self.impute_value, (int, float)) and not isinstance(
             self.impute_value, bool
         ):
-            imp = _NumberImputer(
+            imp = NumberImputer(
                 columns=self.columns,
                 impute_value=self.impute_value,
                 return_native=self.return_native,

--- a/tubular/imputers.py
+++ b/tubular/imputers.py
@@ -376,7 +376,7 @@ class NumberImputer(BaseImputer):
 
         if bad_types:
             msg = f"""
-                ArbitraryImputer: transformer can only handle Float/Int/UInt/Unknown type columns
+                {self.classname()}: transformer can only handle Float/Int/UInt/Unknown type columns
                 but got columns with types {bad_types}
                 """
             raise TypeError(


### PR DESCRIPTION
added tests for NumberImputer, and exposed as public class 
https://github.com/azukds/tubular/issues/752

For this one, mainly focused on replicating ArbitraryImputers test coverage for numeric columns, so can the reviewer please also spend some time reading through the old tests and double checking that we haven't lost any cases in the move. (I think ArbitraryImputer tests contained some duplicated cases, so I haven't copied over each test, but tried to condense down)